### PR TITLE
[AD-240] Allow "latest or none" option so we don't always generate a schema

### DIFF
--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbDatabaseSchemaMetadata.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbDatabaseSchemaMetadata.java
@@ -30,6 +30,11 @@ import java.util.Objects;
  * virtual tables.
  */
 public final class DocumentDbDatabaseSchemaMetadata {
+
+    public static final int VERSION_LATEST_OR_NEW = 0;
+    public static final int VERSION_NEW = -1;
+    public static final int VERSION_LATEST_OR_NONE = -2;
+
     private final DocumentDbSchema schema;
 
     /**
@@ -64,26 +69,10 @@ public final class DocumentDbDatabaseSchemaMetadata {
         this.schema = schema;
     }
 
-    /**
-     * Constructs a {@link DocumentDbDatabaseSchemaMetadata} instance using the default schema name
-     * with an option to refresh all the table schema.
-     *
-     * @param properties the connection properties.
-     * @param refreshAll an indicator of whether to refresh all the table schema.
-     * @return a new {@link DocumentDbDatabaseSchemaMetadata} instance.
-     *
-     * @throws SQLException if a SQL exception occurs.
-     */
-    public static DocumentDbDatabaseSchemaMetadata get(
-            final DocumentDbConnectionProperties properties,
-            final boolean refreshAll) throws SQLException {
-        return get(properties, DocumentDbSchema.DEFAULT_SCHEMA_NAME, refreshAll);
-    }
-
 
     /**
      * Gets the latest or a new {@link DocumentDbDatabaseSchemaMetadata} instance based on the
-     * schemaName and properties. It uses a value of {@link DocumentDbMetadataService#VERSION_LATEST}
+     * schemaName and properties. It uses a value of {@link DocumentDbDatabaseSchemaMetadata#VERSION_LATEST_OR_NEW}
      * for the version to indicate to get the latest or create a new instance if none exists.
      *
      * @param properties the connection properties.
@@ -93,39 +82,9 @@ public final class DocumentDbDatabaseSchemaMetadata {
     public static DocumentDbDatabaseSchemaMetadata get(
             final DocumentDbConnectionProperties properties, final String schemaName)
             throws SQLException {
-        return get(properties, schemaName, false);
+        return get(properties, schemaName, VERSION_LATEST_OR_NEW);
     }
 
-    /**
-     * Gets the {@link DocumentDbDatabaseSchemaMetadata} by given schema name, connection properties
-     * and an indicator of whether to refresh the metadata from the cached version.
-     *
-     * @param properties the connection properties.
-     * @param schemaName the schema name.
-     * @param refreshAll an indicator of whether to get refreshed metadata and ignore the cached
-     *                   version.
-     * @return a {@link DocumentDbDatabaseSchemaMetadata} instance.
-     */
-    public static DocumentDbDatabaseSchemaMetadata get(
-            final DocumentDbConnectionProperties properties,
-            final String schemaName,
-            final boolean refreshAll) throws SQLException {
-
-        final DocumentDbDatabaseSchemaMetadata metadata;
-        final int schemaVersion = refreshAll
-                ? DocumentDbMetadataService.VERSION_NEW
-                : DocumentDbMetadataService.VERSION_LATEST;
-        final DocumentDbSchema schema = DocumentDbMetadataService
-                .get(properties, schemaName, schemaVersion);
-        if (schema != null) {
-            // Setup lazy load based on table ID.
-            setSchemaGetTableFunction(properties, schemaName, schemaVersion, schema);
-            metadata = new DocumentDbDatabaseSchemaMetadata(schema);
-        } else {
-            metadata = null;
-        }
-        return metadata;
-    }
 
     /**
      * Gets an existing {@link DocumentDbDatabaseSchemaMetadata} instance based on the schema name
@@ -134,7 +93,7 @@ public final class DocumentDbDatabaseSchemaMetadata {
      * @param properties the properties of the connection.
      * @param schemaName the name of the schema.
      * @param schemaVersion the version of the schema. A version number of
-     *                {@link DocumentDbMetadataService#VERSION_LATEST} indicates to get the latest
+     *                {@link DocumentDbDatabaseSchemaMetadata#VERSION_LATEST_OR_NEW} indicates to get the latest
      *                or create a new instance.
      * @return a {@link DocumentDbDatabaseSchemaMetadata} instance if the schema and version exist,
      * null otherwise.

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbMetadataTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbMetadataTest.java
@@ -35,6 +35,9 @@ import java.sql.SQLException;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_LATEST_OR_NEW;
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_NEW;
+
 class DocumentDbMetadataTest {
 
     // Need to start and stop the test environment between tests to clear the collections.
@@ -73,14 +76,14 @@ class DocumentDbMetadataTest {
 
         // Even though we've added data, we're not refreshing, so expecting 0.
         final DocumentDbDatabaseSchemaMetadata databaseMetadata00 = DocumentDbDatabaseSchemaMetadata
-                .get(properties, schemaName, false);
+                .get(properties, schemaName, VERSION_LATEST_OR_NEW);
         Assertions.assertEquals(0, databaseMetadata00.getTableSchemaMap().size());
         Assertions.assertEquals(1, databaseMetadata0.getSchemaVersion());
         Assertions.assertEquals(0, databaseMetadata0.getTableSchemaMap().size());
 
         // Now use the "refreshAll=true" flag to re-read the collection(s).
         final DocumentDbDatabaseSchemaMetadata databaseMetadata1 = DocumentDbDatabaseSchemaMetadata
-                .get(properties, schemaName, true);
+                .get(properties, schemaName, VERSION_NEW);
 
         Assertions.assertEquals(1,
                 databaseMetadata1.getTableSchemaMap().size());
@@ -121,7 +124,7 @@ class DocumentDbMetadataTest {
 
         // Now use the "refreshAll=true" flag to re-read the collection(s).
         final DocumentDbDatabaseSchemaMetadata databaseMetadata1 = DocumentDbDatabaseSchemaMetadata
-                .get(properties, schemaName, true);
+                .get(properties, schemaName, VERSION_NEW);
 
         Assertions.assertEquals(1,
                 databaseMetadata1.getTableSchemaMap().size());
@@ -164,7 +167,7 @@ class DocumentDbMetadataTest {
 
         // Now use the "refreshAll=true" flag to re-read the collection(s).
         final DocumentDbDatabaseSchemaMetadata databaseMetadata1 = DocumentDbDatabaseSchemaMetadata
-                .get(properties, schemaName, true);
+                .get(properties, schemaName, VERSION_NEW);
 
         Assertions.assertEquals(1,
                 databaseMetadata1.getTableSchemaMap().size());
@@ -201,7 +204,7 @@ class DocumentDbMetadataTest {
 
         // Now use the "refreshAll=true" flag to re-read the collection(s).
         final DocumentDbDatabaseSchemaMetadata databaseMetadata1 = DocumentDbDatabaseSchemaMetadata
-                .get(properties, schemaName, true);
+                .get(properties, schemaName, VERSION_NEW);
 
         Assertions.assertEquals(1,
                 databaseMetadata1.getTableSchemaMap().size());

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceTest.java
@@ -34,6 +34,8 @@ import software.amazon.documentdb.jdbc.persist.SchemaWriter;
 
 import java.sql.SQLException;
 
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_NEW;
+
 @ExtendWith(DocumentDbFlapDoodleExtension.class)
 public class DocumentDbQueryMappingServiceTest extends DocumentDbFlapDoodleTest {
     private static final String DATABASE_NAME = "database";
@@ -65,7 +67,7 @@ public class DocumentDbQueryMappingServiceTest extends DocumentDbFlapDoodleTest 
         insertBsonDocuments(
                 OTHER_COLLECTION_NAME, DATABASE_NAME, "user", "password", new BsonDocument[] {otherDocument});
         final DocumentDbDatabaseSchemaMetadata databaseMetadata =
-                DocumentDbDatabaseSchemaMetadata.get(connectionProperties, "id", true);
+                DocumentDbDatabaseSchemaMetadata.get(connectionProperties, "id", VERSION_NEW);
         queryMapper = new DocumentDbQueryMappingService(connectionProperties, databaseMetadata);
     }
 

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
@@ -37,6 +37,8 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.Executor;
 
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_LATEST_OR_NEW;
+
 /**
  * DocumentDb implementation of Connection.
  */
@@ -104,7 +106,7 @@ public class DocumentDbConnection extends Connection
     private void ensureDatabaseMetadata() throws SQLException {
         if (metadata == null) {
             databaseMetadata = DocumentDbDatabaseSchemaMetadata.get(
-                    connectionProperties, connectionProperties.getSchemaName(), false);
+                    connectionProperties, connectionProperties.getSchemaName(), VERSION_LATEST_OR_NEW);
             metadata = new DocumentDbDatabaseMetaData(this, databaseMetadata, connectionProperties);
         }
     }

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbMain.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbMain.java
@@ -84,6 +84,8 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.USER_HOME_PROPERTY;
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_LATEST_OR_NONE;
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_NEW;
 import static software.amazon.documentdb.jdbc.metadata.DocumentDbSchema.SQL_NAME_PROPERTY;
 import static software.amazon.documentdb.jdbc.metadata.DocumentDbSchemaTable.COLLECTION_NAME_PROPERTY;
 import static software.amazon.documentdb.jdbc.metadata.DocumentDbSchemaTable.COLUMNS_PROPERTY;
@@ -513,7 +515,11 @@ public class DocumentDbMain {
                 ? Arrays.asList(requestedTableNames)
                 : new ArrayList<>();
         final DocumentDbDatabaseSchemaMetadata schema = DocumentDbDatabaseSchemaMetadata
-                .get(properties, properties.getSchemaName(), false);
+                .get(properties, properties.getSchemaName(), VERSION_LATEST_OR_NONE);
+        if (schema == null) {
+            // No schema to export.
+            return;
+        }
         final Set<String> availTableSet = schema.getTableSchemaMap().keySet();
         if (requestedTableList.isEmpty()) {
             requestedTableList.addAll(availTableSet);
@@ -598,7 +604,7 @@ public class DocumentDbMain {
             final DocumentDbConnectionProperties properties,
             final StringBuilder output) throws SQLException {
         final DocumentDbDatabaseSchemaMetadata schema = DocumentDbDatabaseSchemaMetadata
-                .get(properties, properties.getSchemaName(), false);
+                .get(properties, properties.getSchemaName(), VERSION_LATEST_OR_NONE);
         if (schema != null) {
             final List<String> sortedTableNames = schema.getTableSchemaMap().keySet().stream()
                     .sorted()
@@ -625,7 +631,7 @@ public class DocumentDbMain {
             final DocumentDbConnectionProperties properties,
             final StringBuilder output) throws SQLException {
         final DocumentDbDatabaseSchemaMetadata schema =  DocumentDbDatabaseSchemaMetadata
-                .get(properties, properties.getSchemaName(), true);
+                .get(properties, properties.getSchemaName(), VERSION_NEW);
         if (schema != null) {
             output.append(String.format(NEW_SCHEMA_VERSION_GENERATED_MESSAGE,
                     schema.getSchemaName(),

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbMainTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbMainTest.java
@@ -317,6 +317,20 @@ class DocumentDbMainTest {
                     DEFAULT_SCHEMA_NAME,
                     CUSTOM_SCHEMA_NAME),
                     output.toString().replaceAll(", Modified=.*", ""));
+
+            // Ensure listing schemas doesn't create a new schema
+            args = buildArguments("-r", CUSTOM_SCHEMA_NAME);
+            output.setLength(0);
+            DocumentDbMain.handleCommandLine(args, output);
+            Assertions.assertEquals(String.format("Removed schema '%s'.", CUSTOM_SCHEMA_NAME), output.toString());
+            args = buildArguments("-r", DEFAULT_SCHEMA_NAME);
+            output.setLength(0);
+            DocumentDbMain.handleCommandLine(args, output);
+            Assertions.assertEquals(String.format("Removed schema '%s'.", DEFAULT_SCHEMA_NAME), output.toString());
+            args = buildArguments("-l", CUSTOM_SCHEMA_NAME);
+            output.setLength(0);
+            DocumentDbMain.handleCommandLine(args, output);
+            Assertions.assertEquals(0, output.length());
         } finally {
             dropCollection(testEnvironment, collectionName1);
             dropCollection(testEnvironment, collectionName2);
@@ -369,6 +383,16 @@ class DocumentDbMainTest {
                     + "%s\n",
                     formatArgs.toArray()),
                     actual);
+
+            // Ensure listing tables doesn't create a new schema
+            args = buildArguments("-r", CUSTOM_SCHEMA_NAME);
+            output.setLength(0);
+            DocumentDbMain.handleCommandLine(args, output);
+            Assertions.assertEquals(String.format("Removed schema '%s'.", CUSTOM_SCHEMA_NAME), output.toString());
+            args = buildArguments("-b", CUSTOM_SCHEMA_NAME);
+            output.setLength(0);
+            DocumentDbMain.handleCommandLine(args, output);
+            Assertions.assertEquals(0, output.length());
         } finally {
             dropCollection(testEnvironment, collectionName1);
             dropCollection(testEnvironment, collectionName2);

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutorTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutorTest.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 
 import static software.amazon.documentdb.jdbc.DocumentDbStatementTest.getDocumentDbStatement;
+import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_NEW;
 
 @ExtendWith(DocumentDbFlapDoodleExtension.class)
 public class DocumentDbQueryExecutorTest extends DocumentDbFlapDoodleTest {
@@ -72,7 +73,7 @@ public class DocumentDbQueryExecutorTest extends DocumentDbFlapDoodleTest {
         prepareSimpleConsistentData(DATABASE_NAME, collectionSimple,
                 5, TEST_USER, TEST_PASSWORD);
         final DocumentDbDatabaseSchemaMetadata databaseMetadata = DocumentDbDatabaseSchemaMetadata
-                .get(VALID_CONNECTION_PROPERTIES, "id", true);
+                .get(VALID_CONNECTION_PROPERTIES, "id", VERSION_NEW);
         final DocumentDbQueryMappingService queryMapper = new DocumentDbQueryMappingService(
                 VALID_CONNECTION_PROPERTIES, databaseMetadata);
         final DocumentDbStatement statement = getDocumentDbStatement();


### PR DESCRIPTION
### Summary

[AD-240](https://bitquill.atlassian.net/browse/AD-240) Allow "latest or none" option so we don't always generate a schema.


### Description

Add option to get latest or none - so we don' always generate a new schema.

### Related Issue

https://bitquill.atlassian.net/browse/AD-240

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
