### PR TITLE
AD-241 Error when querying >20000 rows

### DIFF
--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/Statement.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/Statement.java
@@ -216,16 +216,14 @@ public abstract class Statement implements java.sql.Statement {
     @Override
     public void setFetchSize(final int rows) throws SQLException {
         verifyOpen();
-        if (rows < 1) {
+        if (rows < 0) {
             throw SqlError.createSQLException(
                     LOGGER,
                     SqlState.DATA_EXCEPTION,
                     SqlError.INVALID_FETCH_SIZE,
                     rows);
         }
-
-        // Silently truncate to the maximum number of rows that can be retrieved at a time.
-        this.fetchSize = Math.min(rows, getMaxFetchSize());
+        this.fetchSize = rows;
     }
 
     @Override
@@ -437,11 +435,4 @@ public abstract class Statement implements java.sql.Statement {
      * @throws SQLException - if a database exception occurs
      */
     protected abstract void cancelQuery() throws SQLException;
-
-    /**
-     * Gets the maximum number of rows to fetch.
-     * @return A value representing the maximum number of rows to fetch.
-     * @throws SQLException - if a database exception occurs
-     */
-    protected abstract int getMaxFetchSize() throws SQLException;
 }

--- a/common/src/test/java/software/amazon/documentdb/jdbc/common/StatementTest.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/common/StatementTest.java
@@ -47,7 +47,7 @@ public class StatementTest {
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchDirection(ResultSet.FETCH_FORWARD));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setEscapeProcessing(false));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchSize(0));
-        HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchSize(1));
+        HelperFunctions.expectFunctionThrows(() -> statement.setFetchSize(-1));
         HelperFunctions.expectFunctionThrows(() -> statement.setLargeMaxRows(-1));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setLargeMaxRows(1));
         HelperFunctions.expectFunctionThrows(() -> statement.setMaxFieldSize(-1));

--- a/common/src/test/java/software/amazon/documentdb/jdbc/common/StatementTest.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/common/StatementTest.java
@@ -46,7 +46,7 @@ public class StatementTest {
         HelperFunctions.expectFunctionThrows(() -> statement.setFetchDirection(ResultSet.FETCH_REVERSE));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchDirection(ResultSet.FETCH_FORWARD));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setEscapeProcessing(false));
-        HelperFunctions.expectFunctionThrows(() -> statement.setFetchSize(0));
+        HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchSize(0));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setFetchSize(1));
         HelperFunctions.expectFunctionThrows(() -> statement.setLargeMaxRows(-1));
         HelperFunctions.expectFunctionDoesntThrow(() -> statement.setLargeMaxRows(1));

--- a/common/src/test/java/software/amazon/documentdb/jdbc/common/mock/MockPreparedStatement.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/common/mock/MockPreparedStatement.java
@@ -52,11 +52,6 @@ public class MockPreparedStatement extends PreparedStatement implements java.sql
     }
 
     @Override
-    protected int getMaxFetchSize() throws SQLException {
-        return 0;
-    }
-
-    @Override
     public int getQueryTimeout() throws SQLException {
         return 0;
     }

--- a/common/src/test/java/software/amazon/documentdb/jdbc/common/mock/MockStatement.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/common/mock/MockStatement.java
@@ -45,11 +45,6 @@ public class MockStatement extends Statement implements java.sql.Statement {
     }
 
     @Override
-    protected int getMaxFetchSize() throws SQLException {
-        return 0;
-    }
-
-    @Override
     public ResultSet executeQuery(final String sql) throws SQLException {
         return resultSet;
     }

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbPreparedStatement.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbPreparedStatement.java
@@ -50,15 +50,9 @@ public class DocumentDbPreparedStatement extends PreparedStatement
     }
 
     @Override
-    protected int getMaxFetchSize() throws SQLException {
-        verifyOpen();
-        return Integer.MAX_VALUE;
-    }
-
-    @Override
     public java.sql.ResultSet executeQuery() throws SQLException {
         verifyOpen();
-        return DocumentDbStatement.executeQuery(getSql(), this, getMaxFetchSize());
+        return DocumentDbStatement.executeQuery(getSql(), this, getFetchSize());
     }
 
     @Override

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -94,7 +94,7 @@ public class DocumentDbQueryExecutor {
         }
         if (getFetchSize() > 0) {
             iterable = iterable.batchSize(getFetchSize());
-        };
+        }
         final MongoCursor<Document> iterator = iterable.iterator();
 
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  * DocumentDb implementation of QueryExecution.
  */
 public class DocumentDbQueryExecutor {
-    private final int maxFetchSize;
+    private final int fetchSize;
     private final java.sql.Statement statement;
     private final String uri;
     private final int queryTimeout;
@@ -51,11 +51,11 @@ public class DocumentDbQueryExecutor {
             final String uri,
             final DocumentDbQueryMappingService queryMapper,
             final int queryTimeoutSecs,
-            final int maxFetchSize) {
+            final int fetchSize) {
         this.statement = statement;
         this.uri = uri;
         this.queryMapper = queryMapper;
-        this.maxFetchSize = maxFetchSize;
+        this.fetchSize = fetchSize;
         this.queryTimeout = queryTimeoutSecs;
     }
 
@@ -64,8 +64,8 @@ public class DocumentDbQueryExecutor {
         throw new SQLFeatureNotSupportedException();
     }
 
-    protected int getMaxFetchSize() throws SQLException {
-        return maxFetchSize;
+    protected int getFetchSize() throws SQLException {
+        return fetchSize;
     }
 
     /**
@@ -88,13 +88,13 @@ public class DocumentDbQueryExecutor {
         final MongoCollection<Document> collection = database
                 .getCollection(queryContext.getCollectionName());
         AggregateIterable<Document> iterable = collection
-                .aggregate(queryContext.getAggregateOperations()).batchSize(Integer.MAX_VALUE);
+                .aggregate(queryContext.getAggregateOperations());
         if (getQueryTimeout() > 0) {
             iterable = iterable.maxTime(getQueryTimeout(), TimeUnit.SECONDS);
         }
-        if (getMaxFetchSize() > 0) {
-            iterable = iterable.batchSize(getMaxFetchSize());
-        }
+        if (getFetchSize() > 0) {
+            iterable = iterable.batchSize(getFetchSize());
+        };
         final MongoCursor<Document> iterator = iterable.iterator();
 
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbResultSet.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbResultSet.java
@@ -17,6 +17,7 @@
 package software.amazon.documentdb.jdbc;
 
 import com.google.common.collect.ImmutableList;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCursor;
 import org.bson.Document;
 import org.bson.types.Binary;
@@ -44,6 +45,7 @@ public class DocumentDbResultSet extends DocumentDbAbstractResultSet implements 
     private final MongoCursor<Document> iterator;
     private Document current;
     private final List<String> paths;
+    private final MongoClient client;
 
     /**
      * DocumentDbResultSet constructor, initializes super class.
@@ -52,18 +54,21 @@ public class DocumentDbResultSet extends DocumentDbAbstractResultSet implements 
             final Statement statement,
             final MongoCursor<Document> iterator,
             final ImmutableList<JdbcColumnMetaData> columnMetaData,
-            final List<String> paths) throws SQLException {
+            final List<String> paths,
+            final MongoClient client) throws SQLException {
         super(statement, columnMetaData, true);
         this.iterator = iterator;
 
         // Set fetch size to be fetch size of statement if it exists. Otherwise, use default.
         this.fetchSize = statement != null ? statement.getFetchSize() : DEFAULT_FETCH_SIZE;
         this.paths = paths;
+        this.client = client;
     }
 
     @Override
     protected void doClose() {
         iterator.close();
+        client.close();
     }
 
     /**

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbStatement.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbStatement.java
@@ -48,15 +48,9 @@ class DocumentDbStatement extends Statement implements java.sql.Statement {
     }
 
     @Override
-    protected int getMaxFetchSize() throws SQLException {
-        verifyOpen();
-        return  Integer.MAX_VALUE;
-    }
-
-    @Override
     public java.sql.ResultSet executeQuery(final String sql) throws SQLException {
         verifyOpen();
-        return executeQuery(sql, this, getMaxFetchSize());
+        return executeQuery(sql, this, getFetchSize());
     }
 
     @Override

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbResultSetTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbResultSetTest.java
@@ -79,6 +79,9 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
     @Mock
     private MongoCursor<Document> iterator;
 
+    @Mock
+    private MongoClient mockClient;
+
 
     private DocumentDbResultSet resultSet;
 
@@ -125,7 +128,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         resultSet =
-                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"));
+                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"), mockClient);
 
         // Test cursor before first row.
         Mockito.when(iterator.hasNext()).thenReturn(true);
@@ -184,7 +187,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         resultSet =
-                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"));
+                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"), mockClient);
 
         // Test going to negative row number. (0 -> -1)
         Mockito.when(iterator.hasNext()).thenReturn(true);
@@ -223,7 +226,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         resultSet =
-                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"));
+                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"), mockClient);
 
         // Test going to valid row number. (0 -> 2)
         Mockito.when(iterator.hasNext()).thenReturn(true);
@@ -256,7 +259,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         resultSet =
-                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"));
+                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"), mockClient);
 
         // Test close.
         Assertions.assertDoesNotThrow(() -> resultSet.close());
@@ -285,7 +288,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
 
         final ImmutableList<JdbcColumnMetaData> columnMetaData =
                 ImmutableList.of(column1, column2, column3);
-        resultSet = new DocumentDbResultSet(mockStatement, iterator, columnMetaData, ImmutableList.of("_id"));
+        resultSet = new DocumentDbResultSet(mockStatement, iterator, columnMetaData, ImmutableList.of("_id"), mockClient);
 
         Assertions.assertEquals(2, resultSet.findColumn("value"));
         Assertions.assertEquals(3, resultSet.findColumn("Value"));
@@ -301,7 +304,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList.of(column);
-        resultSet = new DocumentDbResultSet(mockStatement, iterator, columnMetaData, ImmutableList.of("_id"));
+        resultSet = new DocumentDbResultSet(mockStatement, iterator, columnMetaData, ImmutableList.of("_id"), mockClient);
 
         Assertions.assertEquals(MOCK_FETCH_SIZE, resultSet.getFetchSize());
         Assertions.assertDoesNotThrow(() -> resultSet.setFetchSize(10));
@@ -316,7 +319,7 @@ public class DocumentDbResultSetTest extends DocumentDbFlapDoodleTest {
         final JdbcColumnMetaData column =
                 JdbcColumnMetaData.builder().columnLabel("_id").ordinal(0).build();
         resultSet =
-                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"));
+                new DocumentDbResultSet(mockStatement, iterator, ImmutableList.of(column), ImmutableList.of("_id"), mockClient);
 
         // Try access before first row.
         Assertions.assertEquals("Result set before first row.",

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementBasicTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementBasicTest.java
@@ -830,7 +830,35 @@ public class DocumentDbStatementBasicTest extends DocumentDbStatementTest {
         }
         insertBsonDocuments(tableName, DATABASE_NAME, USER, PASSWORD, docs);
         final Statement statement = getDocumentDbStatement();
-        statement.setFetchSize(10);
+        statement.setFetchSize(1);
+        final ResultSet resultSet = statement.executeQuery(
+                String.format("SELECT * from \"%s\".\"%s\"", DATABASE_NAME, tableName));
+        Assertions.assertNotNull(resultSet);
+        for (int i = 0; i < numDocs; i++) {
+            Assertions.assertTrue(resultSet.next());
+            Assertions.assertEquals(String.valueOf(i), resultSet.getString(1));
+        }
+        Assertions.assertFalse(resultSet.next());
+    }
+
+    /**
+     * Tests that queries with a batch size of zero work.
+     * @throws SQLException if connection or query fails.
+     */
+    @Test
+    @DisplayName("Tests that a batch size of zero works.")
+    void testBatchSizeZero() throws SQLException {
+        final String tableName = "testBatchSizeZero";
+        final int numDocs = 10;
+        final BsonDocument[] docs = new BsonDocument[numDocs];
+        for (int i = 0; i < numDocs; i++) {
+            final BsonDocument doc = BsonDocument.parse("{\"_id\": " + i + ", \n" +
+                    "\"field\":\"abc\"}");
+            docs[i] = doc;
+        }
+        insertBsonDocuments(tableName, DATABASE_NAME, USER, PASSWORD, docs);
+        final Statement statement = getDocumentDbStatement();
+        statement.setFetchSize(0);
         final ResultSet resultSet = statement.executeQuery(
                 String.format("SELECT * from \"%s\".\"%s\"", DATABASE_NAME, tableName));
         Assertions.assertNotNull(resultSet);

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementBasicTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementBasicTest.java
@@ -815,7 +815,7 @@ public class DocumentDbStatementBasicTest extends DocumentDbStatementTest {
     /**
      * Tests that the result set of a query does not close prematurely when results are retrieved in multiple batches.
      * Uses max fetch size of 10 to ensure multiple batches are retrieved.
-     * @throws SQLException
+     * @throws SQLException if connection or query fails.
      */
     @Test
     @DisplayName("Tests that the result set does not close prematurely when results are retrieved in multiple batches.")


### PR DESCRIPTION
### Summary

Fix for MongoClient being closed

### Description

Fixes issue when querying where the MongoClient would close too early, due to the try with resources block. This causes problems if the result set is too large, and the MongoCursor needs to fetch more data, as it would fail because the client it holds a reference to was already closed. This error only occurs in large datasets when querying for many rows.

### Related Issue

https://bitquill.atlassian.net/browse/AD-241

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
