### PR TITLE
AD-194 Added fix for Tableau Issue

### DIFF
--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbJoin.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbJoin.java
@@ -320,7 +320,7 @@ public class DocumentDbJoin extends Join implements DocumentDbRel {
         // 1. primary keys,
         // 2. foreign keys (from another table)
         // 3. columns that are "virtual" (i.e. arrays, structures)
-        return table.getColumnMap().values().stream()
+        final List<DocumentDbSchemaColumn> columns =  table.getColumnMap().values().stream()
                 .filter(c -> !c.isPrimaryKey()
                         && c.getForeignKeyTableName() == null
                         && !(c instanceof DocumentDbMetadataColumn &&
@@ -329,7 +329,8 @@ public class DocumentDbJoin extends Join implements DocumentDbRel {
                              c.getSqlType() == JdbcType.ARRAY ||
                              c.getSqlType() == JdbcType.JAVA_OBJECT ||
                              c.getSqlType() == JdbcType.NULL))
-                .collect(ImmutableList.toImmutableList());
+                .collect(Collectors.toList());
+        return ImmutableList.copyOf(columns);
     }
 
     /**


### PR DESCRIPTION
### Summary

Added fix for Tableau version error

### Description

Tableau 2020.4 was unable to retrieve results for virtual tables before. `ImmutableList.toImmutableList()` seemed to be causing the problem based on debug results (toImmutableList() is also tagged with the `@Beta` annotation), and so has been replaced with `ImmutableList.copyOf()`. This fixes the issue in Tableau, though I am not sure exactly why.

### Related Issue

https://bitquill.atlassian.net/browse/AD-194

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
