### PR TITLE
[AD-268] Handle case when sub-document (virtual table) contains '_id' as field.

### DIFF
--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGenerator.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGenerator.java
@@ -344,7 +344,7 @@ public class DocumentDbTableSchemaGenerator {
 
         // Ensure virtual table primary key column data types are consistent.
         if (isRootDocument) {
-            checkVirtualTablePrimaryKeys(tableMap, path, columnMap);
+            checkVirtualTablePrimaryKeys(tableMap, collectionName, columnMap);
         }
 
         // Add virtual table.
@@ -796,14 +796,17 @@ public class DocumentDbTableSchemaGenerator {
         }
     }
 
-    private static void checkVirtualTablePrimaryKeys(final Map<String, DocumentDbSchemaTable> tableMap,
-                                                     final String path,
-                                                     final LinkedHashMap<String, DocumentDbSchemaColumn> columnMap) {
+    private static void checkVirtualTablePrimaryKeys(
+            final Map<String, DocumentDbSchemaTable> tableMap,
+            final String path,
+            final LinkedHashMap<String, DocumentDbSchemaColumn> columnMap) {
         final String primaryKeyColumnName = toName(combinePath(path, ID_FIELD_NAME));
-        final DocumentDbMetadataColumn primaryKeyColumn = (DocumentDbMetadataColumn) columnMap.get(primaryKeyColumnName);
+        final DocumentDbMetadataColumn primaryKeyColumn = (DocumentDbMetadataColumn) columnMap
+                .get(primaryKeyColumnName);
         for (DocumentDbSchemaTable table : tableMap.values()) {
-            final DocumentDbMetadataColumn column = (DocumentDbMetadataColumn) table.getColumnMap().get(primaryKeyColumnName);
-            if (column != null) {
+            final DocumentDbMetadataColumn column = (DocumentDbMetadataColumn) table
+                    .getColumnMap().get(primaryKeyColumnName);
+            if (column != null && !column.getSqlType().equals(primaryKeyColumn.getSqlType())) {
                 column.setSqlType(primaryKeyColumn.getSqlType());
             }
         }

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
@@ -1486,6 +1486,47 @@ class DocumentDbTableSchemaGeneratorTest {
         Assertions.assertNotNull(subDoc1);
     }
 
+    @DisplayName("Test whether a sub-document with '_id' as a field is handled correctly.")
+    @Test
+    void testNestedDocumentWithIdInSubDocument() {
+        final String nestedJson = "{\n"
+                + "  \"_id\": { \"$oid\": \"607d96b40352ee001f493a73\" },\n"
+                + "  \"language\": \"en\",\n"
+                + "  \"tags\": [],\n"
+                + "  \"title\": \"TT Eval\",\n"
+                + "  \"name\": \"tt_eval\",\n"
+                + "  \"type\": \"form\",\n"
+                + "  \"created\": \"2021-04-19T14:41:56.252Z\",\n"
+                + "  \"modified\": \"2021-04-19T14:41:56.252Z\",\n"
+                + "  \"owner\": \"12345\",\n"
+                + "  \"components\": [\n"
+                + "    {\n"
+                + "      \"_id\": { \"$oid\": \"607d96b40352ee001f493aca\" },\n"
+                + "      \"label\": \"Objective\",\n"
+                + "      \"required\": false,\n"
+                + "      \"tooltip\": \"additional note go here to describe context of question 54\",\n"
+                + "      \"name\": \"tteval-54\",\n"
+                + "      \"type\": \"section\",\n"
+                + "      \"components\": [\n"
+                + "        {\n"
+                + "          \"_id\": { \"$oid\": \"607d96b50352ee001f493bdc\" },\n"
+                + "          \"label\": \"Strength/ROM\",\n"
+                + "          \"required\": false,\n"
+                + "          \"tooltip\": \"additional note go here to describe context of question 221\",\n"
+                + "          \"name\": \"tteval-221\",\n"
+                + "          \"type\": \"section\",\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ],\n"
+                + "  \"__v\": { \"$numberInt\": \"0\" }\n"
+                + "}\n";
+        final BsonDocument document = BsonDocument.parse(nestedJson);
+        final Map<String, DocumentDbSchemaTable> metadata = DocumentDbTableSchemaGenerator
+                .generate(COLLECTION_NAME, Collections.singleton(document).iterator());
+        Assertions.assertNotNull(metadata);
+    }
+
     private boolean producesVirtualTable(final BsonType bsonType, final BsonType nextBsonType) {
         return (bsonType == BsonType.ARRAY && nextBsonType == BsonType.ARRAY)
                 || (bsonType == BsonType.DOCUMENT && nextBsonType == BsonType.DOCUMENT)


### PR DESCRIPTION
### Summary

[AD-268] Handle case when sub-document (virtual table) contains '_id' as field.

### Description

Now correctly sending the `collectionName` instead of `path`.

### Related Issue

https://bitquill.atlassian.net/browse/AD-268

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
