### PR TITLE
[AD-274] Fix handling of checking for missing database name in connection string.

### DIFF
--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -584,9 +584,9 @@ public class DocumentDbConnectionProperties extends Properties {
         return properties;
     }
 
-    private static void setDatabase(final Properties properties, final URI mongoUri) throws UnsupportedEncodingException,
-            SQLException {
-        if (mongoUri.getPath() == null) {
+    private static void setDatabase(final Properties properties, final URI mongoUri)
+            throws SQLException {
+        if (isNullOrWhitespace(mongoUri.getPath())) {
             if (properties.getProperty(
                     DocumentDbConnectionProperty.DATABASE.getName(), null) == null) {
                 throw SqlError.createSQLException(
@@ -766,9 +766,7 @@ public class DocumentDbConnectionProperties extends Properties {
         }
 
         // Handle the tlsCAFile option.
-        InputStream inputStream = null;
-        try {
-            inputStream = getTlsCAFileInputStream();
+        try (InputStream inputStream = getTlsCAFileInputStream()) {
             if (inputStream != null) {
                 final X509Certificate certificate = (X509Certificate) CertificateFactory
                         .getInstance("X.509")
@@ -778,10 +776,6 @@ public class DocumentDbConnectionProperties extends Properties {
                         .build()
                         .getSslContext();
                 builder.context(sslContext);
-            }
-        } finally {
-            if (inputStream != null) {
-                inputStream.close();
             }
         }
     }

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDriverTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDriverTest.java
@@ -176,6 +176,7 @@ public class DocumentDbDriverTest extends DocumentDbFlapDoodleTest {
             put("jdbc:documentdb://username:password@localhost:1:2/database", "Valid hostname is required to connect. Syntax: 'jdbc:documentdb://[<user>[:<password>]@]<hostname>/<database>[?options...]'");
             put("jdbc:documentdb://username:password@localhost:1/", "Database is required to connect. Syntax: 'jdbc:documentdb://[<user>[:<password>]@]<hostname>/<database>[?options...]'");
             put("jdbc:documentdb://username@localhost:1/database", "User and password are required to connect. Syntax: 'jdbc:documentdb://[<user>[:<password>]@]<hostname>/<database>[?options...]'");
+            put("jdbc:documentdb://username:password@localhost:1?tls=true", "Database is required to connect. Syntax: 'jdbc:documentdb://[<user>[:<password>]@]<hostname>/<database>[?options...]'");
         }};
 
         for (Entry<String, String> test : tests.entrySet()) {


### PR DESCRIPTION
### Summary

[AD-274] Fix handling of checking for missing database name in connection string.

### Description

- Fix handling of checking for missing database name in connection string.

### Related Issue

https://bitquill.atlassian.net/browse/AD-274

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
