### PR TITLE
AD294 - dependabot spotbugsfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'com.github.spotbugs' version '4.5.1'
+    id 'com.github.spotbugs' version '4.7.2'
     id 'checkstyle'
     id 'jacoco'
     id 'com.github.hierynomus.license' version '0.15.0'

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
@@ -21,7 +21,6 @@ import com.mongodb.MongoSecurityException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
-import lombok.SneakyThrows;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +48,8 @@ public class DocumentDbConnection extends Connection
             LoggerFactory.getLogger(DocumentDbConnection.class.getName());
 
     private final DocumentDbConnectionProperties connectionProperties;
-    private DocumentDbDatabaseMetaData metadata;
-    private DocumentDbDatabaseSchemaMetadata databaseMetadata;
+    private final DocumentDbDatabaseMetaData metadata;
+    private final DocumentDbDatabaseSchemaMetadata databaseMetadata;
     private MongoClient mongoClient = null;
     private MongoDatabase mongoDatabase = null;
 
@@ -62,6 +61,9 @@ public class DocumentDbConnection extends Connection
         super(connectionProperties);
         this.connectionProperties = connectionProperties;
         initializeClients(connectionProperties);
+        databaseMetadata = DocumentDbDatabaseSchemaMetadata.get(
+                connectionProperties, connectionProperties.getSchemaName(), VERSION_LATEST_OR_NEW);
+        metadata = new DocumentDbDatabaseMetaData(this, databaseMetadata, connectionProperties);
     }
 
     @Override
@@ -96,24 +98,12 @@ public class DocumentDbConnection extends Connection
         }
     }
 
-    @SneakyThrows
     @Override
-    public DatabaseMetaData getMetaData() throws SQLException {
-        ensureDatabaseMetadata();
+    public DatabaseMetaData getMetaData() {
         return metadata;
     }
 
-    private void ensureDatabaseMetadata() throws SQLException {
-        if (metadata == null) {
-            databaseMetadata = DocumentDbDatabaseSchemaMetadata.get(
-                    connectionProperties, connectionProperties.getSchemaName(), VERSION_LATEST_OR_NEW);
-            metadata = new DocumentDbDatabaseMetaData(this, databaseMetadata, connectionProperties);
-        }
-    }
-
-    DocumentDbDatabaseSchemaMetadata getDatabaseMetadata()
-            throws SQLException {
-        ensureDatabaseMetadata();
+    DocumentDbDatabaseSchemaMetadata getDatabaseMetadata() {
         return databaseMetadata;
     }
 


### PR DESCRIPTION
### Summary

Refactoring to address spot bugs findings 
```
SpotBugs Error
110
	Short Message:		May expose internal representation by returning reference to mutable object
111
	Long Message:		software.amazon.documentdb.jdbc.DocumentDbConnection.getMetaData() may expose internal representation by returning DocumentDbConnection.metadata
112
	Source of Error:	At DocumentDbConnection.java:[line 103]
```

### Description
Refactoring for the metadata, made it final the DocumentDBConnection.

### Related Issue
https://bitquill.atlassian.net/browse/AD-294

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
