### PR TITLE
[AD-298] FIX: Concurrent tests runs fails because of shared schema.

### DIFF
--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbMainTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbMainTest.java
@@ -321,10 +321,11 @@ class DocumentDbMainTest {
             output.setLength(0);
             DocumentDbMain.handleCommandLine(args, output);
             Assertions.assertEquals(String.format(
-                    "Name=%1$s, Version=1, SQL Name=integration%n"
-                            + "Name=%2$s, Version=1, SQL Name=integration%n",
+                    "Name=%1$s, Version=1, SQL Name=%3$s%n"
+                            + "Name=%2$s, Version=1, SQL Name=%3$s%n",
                     DEFAULT_SCHEMA_NAME,
-                    CUSTOM_SCHEMA_NAME),
+                    CUSTOM_SCHEMA_NAME,
+                    testEnvironment.getDatabaseName()),
                     output.toString().replaceAll(", Modified=.*", ""));
 
             // Ensure listing schemas doesn't create a new schema


### PR DESCRIPTION
### Summary

[AD-298] FIX: Concurrent tests runs fails because of shared schema.

### Description

- When using DocumentDB environment, create new database when starting and drop database when stopping.

### Related Issue

https://bitquill.atlassian.net/browse/AD-298

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq
