### PR TITLE
[AD-314] Fix for query execution log

### DIFF
--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -24,6 +24,7 @@ import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import org.bson.BsonDocument;
 import org.bson.Document;
@@ -201,16 +202,16 @@ public class DocumentDbQueryExecutor {
 
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList
                 .copyOf(queryContext.getColumnMetaData());
-        final DocumentDbResultSet resultSet =  new DocumentDbResultSet(
-                this.statement,
-                iterable.iterator(),
-                columnMetaData,
-                queryContext.getPaths());
+        final MongoCursor<Document> iterator = iterable.iterator();
         LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
                 queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
         LOGGER.info("Query {}: Took {} ms to execute query and retrieve first batch of results.", queryId,
                 Instant.now().toEpochMilli() - beginExecution.toEpochMilli());
-        return resultSet;
+        return new DocumentDbResultSet(
+                this.statement,
+                iterator,
+                columnMetaData,
+                queryContext.getPaths());
     }
 
     private void resetQueryState() {

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -201,15 +201,16 @@ public class DocumentDbQueryExecutor {
 
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList
                 .copyOf(queryContext.getColumnMetaData());
-        LOGGER.info("Query {}: Took {} ms to execute query.", queryId,
-                Instant.now().toEpochMilli() - beginExecution.toEpochMilli());
-        LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
-                queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
-        return new DocumentDbResultSet(
+        final DocumentDbResultSet resultSet =  new DocumentDbResultSet(
                 this.statement,
                 iterable.iterator(),
                 columnMetaData,
                 queryContext.getPaths());
+        LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
+                queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
+        LOGGER.info("Query {}: Took {} ms to execute query.", queryId,
+                Instant.now().toEpochMilli() - beginExecution.toEpochMilli());
+        return resultSet;
     }
 
     private void resetQueryState() {

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -208,7 +208,7 @@ public class DocumentDbQueryExecutor {
                 queryContext.getPaths());
         LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
                 queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
-        LOGGER.info("Query {}: Took {} ms to execute query.", queryId,
+        LOGGER.info("Query {}: Took {} ms to execute query and retrieve first batch of results.", queryId,
                 Instant.now().toEpochMilli() - beginExecution.toEpochMilli());
         return resultSet;
     }

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -203,10 +203,10 @@ public class DocumentDbQueryExecutor {
         final ImmutableList<JdbcColumnMetaData> columnMetaData = ImmutableList
                 .copyOf(queryContext.getColumnMetaData());
         final MongoCursor<Document> iterator = iterable.iterator();
-        LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
-                queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
         LOGGER.info("Query {}: Took {} ms to execute query and retrieve first batch of results.", queryId,
                 Instant.now().toEpochMilli() - beginExecution.toEpochMilli());
+        LOGGER.debug("Query {}: Executed on collection {} with following pipeline operations: {}",
+                queryId, queryContext.getCollectionName(), queryContext.getAggregateOperations().toString());
         return new DocumentDbResultSet(
                 this.statement,
                 iterator,


### PR DESCRIPTION
### Summary

Fix Logging of Query Execution Time

### Description

Adjusted logging to include time taken to create the result set, which includes execution and fetch time.

### Related Issue

https://bitquill.atlassian.net/browse/AD-314

### Additional Reviewers
@birschick-bq
@mitchell-elholm
@alexey-temnikov 
@andiem-bq

