### PR TITLE
FIX: [BugBash] Tableau Connector: if SSH tunnel enabled, disable 'Replica Set' option

### DIFF
--- a/docker/TableauConnector/connection-fields.xml
+++ b/docker/TableauConnector/connection-fields.xml
@@ -101,6 +101,9 @@
     </field>
 
     <field name="v-replica-set" label="Enable Replica Set Mode" value-type="boolean" category="advanced" default-value="false">
+        <conditions>
+            <condition field="v-ssh-tunnel" value="false" />
+        </conditions>
         <boolean-options>
             <false-value value="false" />
             <true-value value="true" />

--- a/docker/TableauConnector/connectionProperties.js
+++ b/docker/TableauConnector/connectionProperties.js
@@ -44,7 +44,7 @@
     }
 
     // Use default (and only) replica set.
-    if (attr["v-replica-set"] === "true") {s
+    if (attr["v-replica-set"] === "true") {
         if (attr["v-ssh-tunnel"] === "false") {
             params[REPLICA_SET_KEY] = "rs0";
         }

--- a/docker/TableauConnector/connectionProperties.js
+++ b/docker/TableauConnector/connectionProperties.js
@@ -44,9 +44,12 @@
     }
 
     // Use default (and only) replica set.
-    if (attr["v-replica-set"] === "true") {
-        params[REPLICA_SET_KEY] = "rs0";
+    if (attr["v-replica-set"] === "true") {s
+        if (attr["v-ssh-tunnel"] === "false") {
+            params[REPLICA_SET_KEY] = "rs0";
+        }
     }
+
 
     // Add scan limit if set.
     if (attr["v-scan-limit"]) {


### PR DESCRIPTION
### Summary

FIX: [BugBash] Tableau Connector: if SSH tunnel enabled, disable 'Replica Set' option

### Description

If SSH tunnel is false, the Replica Set parameter will
 not be shown in Tableau Connector Dialog. Unfortunately
 this was rendering in a small bug. If the Replica Set
 was enabled before the SSH tunnel be enabled. The
 Replica Set value was still being set. To fix that a
 small check was added to only set the Replica Set if
ssh tunnel was disabled/false.

### Related Issue

https://bitquill.atlassian.net/browse/AD-327

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
