### PR TITLE
[AD-356] FIX: Console logging level should only be at ERROR level

### DIFF
--- a/common/src/main/resources/log4j.properties
+++ b/common/src/main/resources/log4j.properties
@@ -12,6 +12,7 @@ log4j.appender.console.layout.ConversionPattern=%m%n
 log4j.appender.console.target=System.out
 log4j.appender.console.immediateFlush=true
 log4j.appender.console.encoding=UTF-8
+log4j.appender.console.Threshold=ERROR
 
 log4j.rootCategory=INFO, rollingFile, console
 log4j.logger.performance=INFO, rollingFile


### PR DESCRIPTION
### Summary

[AD-356] FIX: Console logging level should only be at ERROR level

### Description

- Console logging level threshold set to ERROR.

### Related Issue

https://bitquill.atlassian.net/browse/AD-356

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
