### PR TITLE
[AD-365] Documentation: logging level and location

### DIFF
--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -202,8 +202,8 @@ manually delete the old schemas. Exercise caution with this method.
 ## Logs
 
 When troubleshooting, it can be helpful to view the logs so that you might be able 
-to resolve the issue on your own or at least have more context to provide when seeking support.  
-The driver's logs will be written to `/tmp/logs/DocumentDB_JDBC.log`.
+to resolve the issue on your own or at least have more context to provide when seeking support. 
+The driver's logs will be written to `/.documentdb/logs/documentdb-jdbc.log`.
 
 Many BI tools also provide an interface for users to easily view logs. Tableau, for example, 
 has [Tableau Log Viewer](https://github.com/tableau/tableau-log-viewer). 

--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -212,3 +212,50 @@ under `Documents` although this may vary depending on how Tableau was installed.
 The JDBC driver's logs will be in the `jprotocolserver.log` file. 
 
 Refer to the documentation of your tool of choice for similar instructions.
+
+### Setting Logging Level and Location
+There are the following levels of logging:
+
+~~~
+FATAL: shows messages at a FATAL level only
+ERROR: shows messages classified as ERROR and FATAL
+WARNING: shows messages classified as WARNING, ERROR and FATAL
+INFO: shows messages classified as INFO, WARNING, ERROR and FATAL
+DEBUG: shows messages classified as DEBUG, INFO, WARNING, ERROR and FATAL
+TRACE: shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL
+ALL: shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL
+OFF: no log messages displayed    
+~~~
+
+The level for all sources/appenders is: 
+- `documentdb.jdbc.log.level=<log-level>` 
+- default: `<log-level>=INFO`
+
+The location for file logging is: 
+- `documentdb.jdbc.log.file.path=<full-log-file-path>` 
+- default: `<full-log-file-path>=~/.documentdb/logs/documentdb-jdbc.log`
+
+The threshold for file logging is: 
+- `documentdb.jdbc.log.file.threshold=<file-threshold-level>` 
+- default: `<file-threshold-level>=ALL`
+
+The threshold for console logging is: 
+- `documentdb.jdbc.log.console.threshold=<console-threshold-level>` 
+- default: `<console-threshold-level>=ERROR`
+
+To set these properties, use the `JAVA_TOOL_OPTIONS` environment variables with the following format 
+`-D<prop-name>=<prop-value>`. 
+
+For example:
+- In Windows:`set JAVA_TOOL_OPTIONS=-Ddocumentdb.jdbc.log.level=DEBUG`
+- In MacOS/Linux: `export JAVA_TOOL_OPTIONS=-Ddocumentdb.jdbc.log.level=DEBUG`
+    - Or in DbVisualizer Tools Properties:
+        - `-Ddocumentdb.jdbc.log.level=DEBUG`
+        - `-Ddocumentdb.jdbc.log.console.threshold=ALL`
+        - Additionally the following files `slf4j-api.jar` and `slf4j-nop.jar` needs to be removed from the DbVisualizer 
+        `lib` folder.
+        
+- In Tableau, a parameter must be used in the command line or terminal:
+    - In Windows: `start "" "c:\program files\Tableau\Tableau [version]\bin\tableau.exe" -DLogLevel=DEBUG`
+    - In MacOS: `/Applications/Tableau\ Desktop\[version].app/Contents/MacOS/Tableau -DLogLevel=DEBUG`
+    - Tableau logs are located at: `{user.home}/Documents/My Tableau Repository/Logs`

--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -249,7 +249,7 @@ To set these properties, use the `JAVA_TOOL_OPTIONS` environment variables with 
 For example:
 - In Windows:`set JAVA_TOOL_OPTIONS=-Ddocumentdb.jdbc.log.level=DEBUG`
 - In MacOS/Linux: `export JAVA_TOOL_OPTIONS=-Ddocumentdb.jdbc.log.level=DEBUG`
-    - Or in DbVisualizer Tools Properties:
+    - Or in DbVisualizer Tools Properties (version 12.1.2 or later):
         - `-Ddocumentdb.jdbc.log.level=DEBUG`
         - `-Ddocumentdb.jdbc.log.console.threshold=ALL`
         - Additionally the following files `slf4j-api.jar` and `slf4j-nop.jar` needs to be removed from the DbVisualizer 

--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -216,35 +216,26 @@ Refer to the documentation of your tool of choice for similar instructions.
 ### Setting Logging Level and Location
 There are the following levels of logging:
 
-~~~
-FATAL: shows messages at a FATAL level only
-ERROR: shows messages classified as ERROR and FATAL
-WARNING: shows messages classified as WARNING, ERROR and FATAL
-INFO: shows messages classified as INFO, WARNING, ERROR and FATAL
-DEBUG: shows messages classified as DEBUG, INFO, WARNING, ERROR and FATAL
-TRACE: shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL
-ALL: shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL
-OFF: no log messages displayed    
-~~~
+| Property Value | Description |
+|--------|-------------|
+| `FATAL` | Shows messages at a FATAL level only.|
+| `ERROR` | Shows messages classified as ERROR and FATAL.|
+| `WARNING` | Shows messages classified as WARNING, ERROR and FATAL.|
+| `INFO` | Shows messages classified as INFO, WARNING, ERROR and FATAL.|
+| `DEBUG` | Shows messages classified as DEBUG, INFO, WARNING, ERROR and FATAL.|
+| `TRACE` | Shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL.|
+| `ALL` | Shows messages classified as TRACE, DEBUG, INFO, WARNING, ERROR and FATAL.|
+| `OFF` | No log messages displayed.|
 
-The level for all sources/appenders is: 
-- `documentdb.jdbc.log.level=<log-level>` 
-- default: `<log-level>=INFO`
-
-The location for file logging is: 
-- `documentdb.jdbc.log.file.path=<full-log-file-path>` 
-- default: `<full-log-file-path>=~/.documentdb/logs/documentdb-jdbc.log`
-
-The threshold for file logging is: 
-- `documentdb.jdbc.log.file.threshold=<file-threshold-level>` 
-- default: `<file-threshold-level>=ALL`
-
-The threshold for console logging is: 
-- `documentdb.jdbc.log.console.threshold=<console-threshold-level>` 
-- default: `<console-threshold-level>=ERROR`
+| Property Name | Description | Default |
+|--------|-------------|---------------|
+| `documentdb.jdbc.log.level` | The log level for all sources/appenders. | `INFO` |
+| `documentdb.jdbc.log.file.path` | The location for file logging. | `~/.documentdb/logs/documentdb-jdbc.log` |
+| `documentdb.jdbc.log.file.threshold` | The threshold for file logging. | `ALL` |
+| `documentdb.jdbc.log.console.threshold` | The threshold for console logging. | `ERROR` |
 
 To set these properties, use the `JAVA_TOOL_OPTIONS` environment variables with the following format 
-`-D<prop-name>=<prop-value>`. 
+`-D<property-name>=<property-value>`. 
 
 For example:
 - In Windows:`set JAVA_TOOL_OPTIONS=-Ddocumentdb.jdbc.log.level=DEBUG`

--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -203,7 +203,7 @@ manually delete the old schemas. Exercise caution with this method.
 
 When troubleshooting, it can be helpful to view the logs so that you might be able 
 to resolve the issue on your own or at least have more context to provide when seeking support. 
-The driver's logs will be written to `/.documentdb/logs/documentdb-jdbc.log`.
+The driver's logs will be written to `~/.documentdb/logs/documentdb-jdbc.log`.
 
 Many BI tools also provide an interface for users to easily view logs. Tableau, for example, 
 has [Tableau Log Viewer](https://github.com/tableau/tableau-log-viewer). 


### PR DESCRIPTION
### Summary

- Added documentation on setting log level and location 
- Transferred from other PR. Already approved. Original PR linked in ticket.

### Related Issue
https://bitquill.atlassian.net/browse/AD-365

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
@mitchell-elholm
