### PR TITLE
FIX: ssh key passphrase is set to null when passphrase is provided

### DIFF
--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
@@ -327,7 +327,7 @@ public class DocumentDbConnection extends Connection
             final JSch jSch) throws JSchException {
         final String privateKey = getPath(connectionProperties.getSshPrivateKeyFile()).toString();
         // If passPhrase protected, will need to provide this, too.
-        final String passPhrase = isNullOrWhitespace(connectionProperties.getSshPrivateKeyPassphrase())
+        final String passPhrase = !isNullOrWhitespace(connectionProperties.getSshPrivateKeyPassphrase())
                 ? connectionProperties.getSshPrivateKeyPassphrase()
                 : null;
         jSch.addIdentity(privateKey, passPhrase);


### PR DESCRIPTION
### Summary

FIX: ssh key passphrase is set to null when passphrase is provided

### Description

passphrase was set to null whenever the user set the ssh key passphrase

### Related Issue

https://bitquill.atlassian.net/browse/AD-369

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
@mitchell-elholm
