### PR TITLE
[AD-373] FIX: Schema generated for nested document within nested array sometimes does not have index

### DIFF
--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
@@ -37,9 +37,7 @@ import org.bson.types.Decimal128;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import software.amazon.documentdb.jdbc.calcite.adapter.DocumentDbSchemaFactory;
 import software.amazon.documentdb.jdbc.common.utilities.JdbcType;
-import software.amazon.documentdb.jdbc.persist.SchemaWriter;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1733,135 +1731,26 @@ class DocumentDbTableSchemaGeneratorTest {
                 .forEach(Assertions::assertTrue);
     }
 
-    @DisplayName("Tests that even deeply nested documents and array have name length less than max.")
+    @DisplayName("Tests that sub-document of array is not present on first document, still should have index column.")
     @Test
-    void testFinraIssue() {
-        final String documentString =
-                "{\n"
-                + "    \"_id\": {\n"
-                + "        \"$oid\": \"60b52ec9277981664d15378d\"\n"
-                + "    },\n"
-                + "    \"createdTimestamp\": {\n"
-                + "        \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
-                + "    },\n"
-                + "    \"createdBy\": \"Trusted User\",\n"
-                + "    \"data\": {\n"
-                + "        \"_id\": {\n"
-                + "            \"$oid\": \"60b52ec7277981664d1536f1\"\n"
-                + "        },\n"
-                + "        \"id\": \"645d7431-8988-46ec-9619-2a6c23699c72\",\n"
-                + "        \"individualCrdNumber\": {\n"
-                + "            \"$numberLong\": \"4945896\"\n"
-                + "        },\n"
-                + "        \"instanceNumber\": {\n"
-                + "            \"$numberLong\": \"2\"\n"
-                + "        },\n"
-                + "        \"firmCrdNumber\": {\n"
-                + "            \"$numberLong\": \"79\"\n"
-                + "        },\n"
-                + "        \"lastReferencedFiling\": {},\n"
-                + "        \"employeeBillingCode\": \"JPM-JPMS\",\n"
-                + "        \"independentContractorFlag\": false,\n"
-                + "        \"status\": {\n"
-                + "            \"code\": \"ACTIVE\",\n"
-                + "            \"ruleTrace\": {\n"
-                + "                \"code\": \"EMPLOYMENT\"\n"
-                + "            },\n"
-                + "            \"startDate\": {\n"
-                + "                \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
-                + "            }\n"
-                + "        },\n"
-                + "        \"roles\": [],\n"
-                + "        \"locations\": [{\n"
-                + "                \"_id\": \"68528a92-6bc2-45f5-9ff4-0317ce99f8f0\",\n"
-                + "                \"typeCode\": \"LOCATEDAT\",\n"
-                + "                \"primary\": {\n"
-                + "                    \"flag\": false,\n"
-                + "                    \"ruleTrace\": {}\n"
-                + "                },\n"
-                + "                \"roleCode\": \"STAFF\",\n"
-                + "                \"startDate\": {\n"
-                + "                    \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
-                + "                },\n"
-                + "                \"endDate\": {\n"
-                + "                    \"$date\": \"2006-05-10T04:00:00.000Z\"\n"
-                + "                },\n"
-                + "                \"nonRegisteredBranch\": {\n"
-                + "                    \"privateResidenceFlag\": false,\n"
-                + "                    \"firmBillingCode\": \"920\",\n"
-                + "                    \"address\": {\n"
-                + "                        \"addressLine1\": \"ONE FEDERAL STREET, 29TH FLOOR\",\n"
-                + "                        \"cityName\": \"BOSTON\",\n"
-                + "                        \"countryCode\": \"USA\",\n"
-                + "                        \"postalCode\": \"02110\",\n"
-                + "                        \"stateCode\": \"MA\"\n"
-                + "                    }\n"
-                + "                }\n"
-                + "            }, {\n"
-                + "                \"_id\": \"ceda889f-8cf4-4f0c-8fb2-e8cfbbcfb796\",\n"
-                + "                \"typeCode\": \"LOCATEDAT\",\n"
-                + "                \"primary\": {\n"
-                + "                    \"flag\": true,\n"
-                + "                    \"ruleTrace\": {\n"
-                + "                        \"code\": \"SET_PRIMARY_LOC_REGISTERED_LOCATED_AT_02\"\n"
-                + "                    }\n"
-                + "                },\n"
-                + "                \"roleCode\": \"STAFF\",\n"
-                + "                \"startDate\": {\n"
-                + "                    \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
-                + "                },\n"
-                + "                \"branchCrdNumber\": {\n"
-                + "                    \"$numberLong\": \"116402\"\n"
-                + "                }\n"
-                + "            }\n"
-                + "        ],\n"
-                + "        \"fingerprint\": {\n"
-                + "            \"classification\": \"PRVD\",\n"
-                + "            \"cards\": [{\n"
-                + "                    \"_id\": \"b9796e19-0ec1-4086-9cfc-0688839c63eb\",\n"
-                + "                    \"ruleTrace\": {\n"
-                + "                        \"code\": \"EMPLOYMENT_FINGERPRINT_ASSOCIATION_03\"\n"
-                + "                    }\n"
-                + "                }\n"
-                + "            ]\n"
-                + "        },\n"
-                + "        \"version\": {\n"
-                + "            \"$numberLong\": \"1\"\n"
-                + "        },\n"
-                + "        \"createdTimestamp\": {\n"
-                + "            \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
-                + "        },\n"
-                + "        \"createdBy\": \"Trusted User\",\n"
-                + "        \"lastModifiedTimestamp\": {\n"
-                + "            \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
-                + "        },\n"
-                + "        \"lastModifiedBy\": \"Trusted User\"\n"
-                + "    },\n"
-                + "    \"_class\": \"org.finra.lara.domain.registration.model.EmploymentHistoryEntity\"\n"
-                + "}\n";
-        final BsonDocument doc = BsonDocument.parse(documentString);
+    void testSubDocumentInArrayOnlyInSecondDocument() {
+        final List<BsonDocument> docs = new ArrayList<>();
+        String documentString;
+        documentString = "{\"_id\":{\"$oid\":\"6050ea8da110dd2c5f279bd0\"},\"data\":{\"_id\":{\"$oid\":\"6050ea8da110dd2c5f279bcf\"},\"locations\":[{\"_id\":\"06c782fe-b89e-43b1-8748-b671ad7d3ad9\"}]}}";
+        docs.add(BsonDocument.parse(documentString));
+        documentString = "{\"_id\":{\"$oid\":\"6050ea8ea110dd2c5f279bd4\"},\"data\":{\"_id\":{\"$oid\":\"6050ea8ea110dd2c5f279bd3\"},\"locations\":[{\"_id\":\"06c782fe-b89e-43b1-8748-b671ad7d3ad9\",\"nonRegisteredBranch\":{\"_id\":\"06c782fe-b89e-43b1-8748-b671ad7d3ad9\"}}]}}";
+        docs.add(BsonDocument.parse(documentString));
+
         final Map<String, DocumentDbSchemaTable> tableMap = DocumentDbTableSchemaGenerator
-                .generate("employmentHistory", Collections.singleton(doc).iterator());
-        // Ensure index column is correctly generated
-        Assertions.assertEquals(14, tableMap.size());
+                .generate("employmentHistory", docs.iterator());
+        Assertions.assertEquals(4, tableMap.size());
         final DocumentDbSchemaTable table1 = tableMap.get("employmentHistory_data_locations");
         Assertions.assertNotNull(table1);
         Assertions.assertNotNull(table1.getColumnMap().get("data_locations_index_lvl_0"));
-        final DocumentDbSchemaTable table2 = tableMap.get("employmentHistory_data_locations_primary");
+        final DocumentDbSchemaTable table2 = tableMap.get(
+                "employmentHistory_data_locations_nonRegisteredBranch");
         Assertions.assertNotNull(table2);
         Assertions.assertNotNull(table2.getColumnMap().get("data_locations_index_lvl_0"));
-        final DocumentDbSchemaTable table3 = tableMap.get("employmentHistory_data_locations_nonRegisteredBranch");
-        Assertions.assertNotNull(table3);
-        Assertions.assertNotNull(table3.getColumnMap().get("data_locations_index_lvl_0"));
-        final DocumentDbSchemaTable table4 = tableMap.get("employmentHistory_data_locations_nonRegisteredBranch_address");
-        Assertions.assertNotNull(table4);
-        Assertions.assertNotNull(table4.getColumnMap().get("data_locations_index_lvl_0"));
-        final DocumentDbSchemaTable table5 = tableMap.get("employmentHistory_data_fingerprint_cards");
-        Assertions.assertNotNull(table5);
-        Assertions.assertNotNull(table5.getColumnMap().get("data_fingerprint_cards_index_lvl_0"));
-        final DocumentDbSchemaTable table6 = tableMap.get("employmentHistory_data_fingerprint_cards_ruleTrace");
-        Assertions.assertNotNull(table6);
-        Assertions.assertNotNull(table6.getColumnMap().get("data_fingerprint_cards_index_lvl_0"));
     }
 
     private boolean producesVirtualTable(final BsonType bsonType, final BsonType nextBsonType) {

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/metadata/DocumentDbTableSchemaGeneratorTest.java
@@ -37,7 +37,9 @@ import org.bson.types.Decimal128;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import software.amazon.documentdb.jdbc.calcite.adapter.DocumentDbSchemaFactory;
 import software.amazon.documentdb.jdbc.common.utilities.JdbcType;
+import software.amazon.documentdb.jdbc.persist.SchemaWriter;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1729,6 +1731,137 @@ class DocumentDbTableSchemaGeneratorTest {
                 .map(schemaColumn -> schemaColumn.getSqlName().length()
                         <= DEFAULT_IDENTIFIER_MAX_LENGTH)
                 .forEach(Assertions::assertTrue);
+    }
+
+    @DisplayName("Tests that even deeply nested documents and array have name length less than max.")
+    @Test
+    void testFinraIssue() {
+        final String documentString =
+                "{\n"
+                + "    \"_id\": {\n"
+                + "        \"$oid\": \"60b52ec9277981664d15378d\"\n"
+                + "    },\n"
+                + "    \"createdTimestamp\": {\n"
+                + "        \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
+                + "    },\n"
+                + "    \"createdBy\": \"Trusted User\",\n"
+                + "    \"data\": {\n"
+                + "        \"_id\": {\n"
+                + "            \"$oid\": \"60b52ec7277981664d1536f1\"\n"
+                + "        },\n"
+                + "        \"id\": \"645d7431-8988-46ec-9619-2a6c23699c72\",\n"
+                + "        \"individualCrdNumber\": {\n"
+                + "            \"$numberLong\": \"4945896\"\n"
+                + "        },\n"
+                + "        \"instanceNumber\": {\n"
+                + "            \"$numberLong\": \"2\"\n"
+                + "        },\n"
+                + "        \"firmCrdNumber\": {\n"
+                + "            \"$numberLong\": \"79\"\n"
+                + "        },\n"
+                + "        \"lastReferencedFiling\": {},\n"
+                + "        \"employeeBillingCode\": \"JPM-JPMS\",\n"
+                + "        \"independentContractorFlag\": false,\n"
+                + "        \"status\": {\n"
+                + "            \"code\": \"ACTIVE\",\n"
+                + "            \"ruleTrace\": {\n"
+                + "                \"code\": \"EMPLOYMENT\"\n"
+                + "            },\n"
+                + "            \"startDate\": {\n"
+                + "                \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
+                + "            }\n"
+                + "        },\n"
+                + "        \"roles\": [],\n"
+                + "        \"locations\": [{\n"
+                + "                \"_id\": \"68528a92-6bc2-45f5-9ff4-0317ce99f8f0\",\n"
+                + "                \"typeCode\": \"LOCATEDAT\",\n"
+                + "                \"primary\": {\n"
+                + "                    \"flag\": false,\n"
+                + "                    \"ruleTrace\": {}\n"
+                + "                },\n"
+                + "                \"roleCode\": \"STAFF\",\n"
+                + "                \"startDate\": {\n"
+                + "                    \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
+                + "                },\n"
+                + "                \"endDate\": {\n"
+                + "                    \"$date\": \"2006-05-10T04:00:00.000Z\"\n"
+                + "                },\n"
+                + "                \"nonRegisteredBranch\": {\n"
+                + "                    \"privateResidenceFlag\": false,\n"
+                + "                    \"firmBillingCode\": \"920\",\n"
+                + "                    \"address\": {\n"
+                + "                        \"addressLine1\": \"ONE FEDERAL STREET, 29TH FLOOR\",\n"
+                + "                        \"cityName\": \"BOSTON\",\n"
+                + "                        \"countryCode\": \"USA\",\n"
+                + "                        \"postalCode\": \"02110\",\n"
+                + "                        \"stateCode\": \"MA\"\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            }, {\n"
+                + "                \"_id\": \"ceda889f-8cf4-4f0c-8fb2-e8cfbbcfb796\",\n"
+                + "                \"typeCode\": \"LOCATEDAT\",\n"
+                + "                \"primary\": {\n"
+                + "                    \"flag\": true,\n"
+                + "                    \"ruleTrace\": {\n"
+                + "                        \"code\": \"SET_PRIMARY_LOC_REGISTERED_LOCATED_AT_02\"\n"
+                + "                    }\n"
+                + "                },\n"
+                + "                \"roleCode\": \"STAFF\",\n"
+                + "                \"startDate\": {\n"
+                + "                    \"$date\": \"2005-09-19T04:00:00.000Z\"\n"
+                + "                },\n"
+                + "                \"branchCrdNumber\": {\n"
+                + "                    \"$numberLong\": \"116402\"\n"
+                + "                }\n"
+                + "            }\n"
+                + "        ],\n"
+                + "        \"fingerprint\": {\n"
+                + "            \"classification\": \"PRVD\",\n"
+                + "            \"cards\": [{\n"
+                + "                    \"_id\": \"b9796e19-0ec1-4086-9cfc-0688839c63eb\",\n"
+                + "                    \"ruleTrace\": {\n"
+                + "                        \"code\": \"EMPLOYMENT_FINGERPRINT_ASSOCIATION_03\"\n"
+                + "                    }\n"
+                + "                }\n"
+                + "            ]\n"
+                + "        },\n"
+                + "        \"version\": {\n"
+                + "            \"$numberLong\": \"1\"\n"
+                + "        },\n"
+                + "        \"createdTimestamp\": {\n"
+                + "            \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
+                + "        },\n"
+                + "        \"createdBy\": \"Trusted User\",\n"
+                + "        \"lastModifiedTimestamp\": {\n"
+                + "            \"$date\": \"2021-05-31T18:45:29.984Z\"\n"
+                + "        },\n"
+                + "        \"lastModifiedBy\": \"Trusted User\"\n"
+                + "    },\n"
+                + "    \"_class\": \"org.finra.lara.domain.registration.model.EmploymentHistoryEntity\"\n"
+                + "}\n";
+        final BsonDocument doc = BsonDocument.parse(documentString);
+        final Map<String, DocumentDbSchemaTable> tableMap = DocumentDbTableSchemaGenerator
+                .generate("employmentHistory", Collections.singleton(doc).iterator());
+        // Ensure index column is correctly generated
+        Assertions.assertEquals(14, tableMap.size());
+        final DocumentDbSchemaTable table1 = tableMap.get("employmentHistory_data_locations");
+        Assertions.assertNotNull(table1);
+        Assertions.assertNotNull(table1.getColumnMap().get("data_locations_index_lvl_0"));
+        final DocumentDbSchemaTable table2 = tableMap.get("employmentHistory_data_locations_primary");
+        Assertions.assertNotNull(table2);
+        Assertions.assertNotNull(table2.getColumnMap().get("data_locations_index_lvl_0"));
+        final DocumentDbSchemaTable table3 = tableMap.get("employmentHistory_data_locations_nonRegisteredBranch");
+        Assertions.assertNotNull(table3);
+        Assertions.assertNotNull(table3.getColumnMap().get("data_locations_index_lvl_0"));
+        final DocumentDbSchemaTable table4 = tableMap.get("employmentHistory_data_locations_nonRegisteredBranch_address");
+        Assertions.assertNotNull(table4);
+        Assertions.assertNotNull(table4.getColumnMap().get("data_locations_index_lvl_0"));
+        final DocumentDbSchemaTable table5 = tableMap.get("employmentHistory_data_fingerprint_cards");
+        Assertions.assertNotNull(table5);
+        Assertions.assertNotNull(table5.getColumnMap().get("data_fingerprint_cards_index_lvl_0"));
+        final DocumentDbSchemaTable table6 = tableMap.get("employmentHistory_data_fingerprint_cards_ruleTrace");
+        Assertions.assertNotNull(table6);
+        Assertions.assertNotNull(table6.getColumnMap().get("data_fingerprint_cards_index_lvl_0"));
     }
 
     private boolean producesVirtualTable(final BsonType bsonType, final BsonType nextBsonType) {


### PR DESCRIPTION
### Summary

[AD-373] FIX: Schema generated for nested document within nested array sometimes does not have index

### Description

Now handling the case where a sub-document in an array is not in the first occurrence of an array.

### Related Issue

https://bitquill.atlassian.net/browse/AD-373

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
