### PR TITLE
[AD-387] Tableau: incorrect error message when connecting with wrong credentials.

### DIFF
--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceMaxRowsTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceMaxRowsTest.java
@@ -132,17 +132,17 @@ public class DocumentDbQueryMappingServiceMaxRowsTest extends DocumentDbFlapDood
         Assertions.assertEquals(5, result.getAggregateOperations().size());
         Assertions.assertEquals(
                 BsonDocument.parse(
-                        "{\"$match\": {\"$or\": ["
-                                + "{\"array.field\": {\"$exists\": true}}, "
-                                + "{\"array.field1\": {\"$exists\": true}}, "
-                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
-                result.getAggregateOperations().get(0));
-        Assertions.assertEquals(
-                BsonDocument.parse(
                         "{ \"$unwind\": {"
                                 + "\"path\": \"$array\", "
                                 + "\"includeArrayIndex\" : \"array_index_lvl_0\", "
                                 + "\"preserveNullAndEmptyArrays\": true }}"),
+                result.getAggregateOperations().get(0));
+        Assertions.assertEquals(
+                BsonDocument.parse(
+                        "{\"$match\": {\"$or\": ["
+                                + "{\"array.field\": {\"$exists\": true}}, "
+                                + "{\"array.field1\": {\"$exists\": true}}, "
+                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
                 result.getAggregateOperations().get(1));
         Assertions.assertEquals(
                 BsonDocument.parse(
@@ -174,17 +174,17 @@ public class DocumentDbQueryMappingServiceMaxRowsTest extends DocumentDbFlapDood
         Assertions.assertEquals(6, result.getAggregateOperations().size());
         Assertions.assertEquals(
                 BsonDocument.parse(
-                        "{\"$match\": {\"$or\": ["
-                                + "{\"array.field\": {\"$exists\": true}}, "
-                                + "{\"array.field1\": {\"$exists\": true}}, "
-                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
-                result.getAggregateOperations().get(0));
-        Assertions.assertEquals(
-                BsonDocument.parse(
                         "{ \"$unwind\": {"
                                 + "\"path\": \"$array\", "
                                 + "\"includeArrayIndex\" : \"array_index_lvl_0\", "
                                 + "\"preserveNullAndEmptyArrays\": true }}"),
+                result.getAggregateOperations().get(0));
+        Assertions.assertEquals(
+                BsonDocument.parse(
+                        "{\"$match\": {\"$or\": ["
+                                + "{\"array.field\": {\"$exists\": true}}, "
+                                + "{\"array.field1\": {\"$exists\": true}}, "
+                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
                 result.getAggregateOperations().get(1));
         Assertions.assertEquals(
                 BsonDocument.parse(
@@ -218,17 +218,17 @@ public class DocumentDbQueryMappingServiceMaxRowsTest extends DocumentDbFlapDood
         Assertions.assertEquals(7, result.getAggregateOperations().size());
         Assertions.assertEquals(
                 BsonDocument.parse(
-                        "{\"$match\": {\"$or\": ["
-                                + "{\"array.field\": {\"$exists\": true}}, "
-                                + "{\"array.field1\": {\"$exists\": true}}, "
-                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
-                result.getAggregateOperations().get(0));
-        Assertions.assertEquals(
-                BsonDocument.parse(
                         "{ \"$unwind\": {"
                                 + "\"path\": \"$array\", "
                                 + "\"includeArrayIndex\" : \"array_index_lvl_0\", "
                                 + "\"preserveNullAndEmptyArrays\": true }}"),
+                result.getAggregateOperations().get(0));
+        Assertions.assertEquals(
+                BsonDocument.parse(
+                        "{\"$match\": {\"$or\": ["
+                                + "{\"array.field\": {\"$exists\": true}}, "
+                                + "{\"array.field1\": {\"$exists\": true}}, "
+                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
                 result.getAggregateOperations().get(1));
         Assertions.assertEquals(
                 BsonDocument.parse(
@@ -272,17 +272,17 @@ public class DocumentDbQueryMappingServiceMaxRowsTest extends DocumentDbFlapDood
         Assertions.assertEquals(8, result.getAggregateOperations().size());
         Assertions.assertEquals(
                 BsonDocument.parse(
-                        "{\"$match\": {\"$or\": ["
-                                + "{\"array.field\": {\"$exists\": true}}, "
-                                + "{\"array.field1\": {\"$exists\": true}}, "
-                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
-                result.getAggregateOperations().get(0));
-        Assertions.assertEquals(
-                BsonDocument.parse(
                         "{ \"$unwind\": {"
                                 + "\"path\": \"$array\", "
                                 + "\"includeArrayIndex\" : \"array_index_lvl_0\", "
                                 + "\"preserveNullAndEmptyArrays\": true }}"),
+                result.getAggregateOperations().get(0));
+        Assertions.assertEquals(
+                BsonDocument.parse(
+                        "{\"$match\": {\"$or\": ["
+                                + "{\"array.field\": {\"$exists\": true}}, "
+                                + "{\"array.field1\": {\"$exists\": true}}, "
+                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
                 result.getAggregateOperations().get(1));
         Assertions.assertEquals(
                 BsonDocument.parse(
@@ -328,17 +328,17 @@ public class DocumentDbQueryMappingServiceMaxRowsTest extends DocumentDbFlapDood
         Assertions.assertEquals(4, result.getAggregateOperations().size());
         Assertions.assertEquals(
                 BsonDocument.parse(
-                        "{\"$match\": {\"$or\": ["
-                                + "{\"array.field\": {\"$exists\": true}}, "
-                                + "{\"array.field1\": {\"$exists\": true}}, "
-                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
-                result.getAggregateOperations().get(0));
-        Assertions.assertEquals(
-                BsonDocument.parse(
                         "{ \"$unwind\": {"
                                 + "\"path\": \"$array\", "
                                 + "\"includeArrayIndex\" : \"array_index_lvl_0\", "
                                 + "\"preserveNullAndEmptyArrays\": true }}"),
+                result.getAggregateOperations().get(0));
+        Assertions.assertEquals(
+                BsonDocument.parse(
+                        "{\"$match\": {\"$or\": ["
+                                + "{\"array.field\": {\"$exists\": true}}, "
+                                + "{\"array.field1\": {\"$exists\": true}}, "
+                                + "{\"array.field2\": {\"$exists\": true}}]}}"),
                 result.getAggregateOperations().get(1));
         Assertions.assertEquals(
                 BsonDocument.parse(

--- a/common/src/main/resources/jdbc.properties
+++ b/common/src/main/resources/jdbc.properties
@@ -81,7 +81,7 @@ MISMATCH_SCHEMA_NAME=Given schema name '%s' does not match stored schema name '%
 QUERY_CANNOT_BE_CANCELED=Cannot cancel query: %s.
 QUERY_IN_PROGRESS=Cannot execute query, another query is already in progress.
 QUERY_NOT_STARTED_OR_COMPLETE=Cannot cancel query, it is either completed or has not started.
-AUTHORIZATION_ERROR=Invalid username or password or user is not authorized on database '%s'. Please check your settings. Authorization failed for user '%s' on database '%s' with mechanism '%s'. Please check user, password, database and authorization for the user.
+AUTHORIZATION_ERROR=Invalid username or password or user is not authorized on database '%s'. Please check your settings. Authorization failed for user '%s' on database '%s' with mechanism '%s'. Please check username, password, database and authorization for the user.
 # SECURITY_ERROR error is provided by the driver
 SECURITY_ERROR=Security error detected: '%s'.
 SINGLE_EQUIJOIN_ONLY=Only a single equality condition is supported for joining tables from different collections. Please refer to the list of the supported features.

--- a/common/src/main/resources/jdbc.properties
+++ b/common/src/main/resources/jdbc.properties
@@ -81,7 +81,7 @@ MISMATCH_SCHEMA_NAME=Given schema name '%s' does not match stored schema name '%
 QUERY_CANNOT_BE_CANCELED=Cannot cancel query: %s.
 QUERY_IN_PROGRESS=Cannot execute query, another query is already in progress.
 QUERY_NOT_STARTED_OR_COMPLETE=Cannot cancel query, it is either completed or has not started.
-AUTHORIZATION_ERROR=Authorization failed for user '%s' on database '%s' with mechanism '%s'.
+AUTHORIZATION_ERROR=Invalid username or password or user is not authorized on database '%s'. Please check your settings. Authorization failed for user '%s' on database '%s' with mechanism '%s'. Please check user, password, database and authorization for the user.
 # SECURITY_ERROR error is provided by the driver
 SECURITY_ERROR=Security error detected: '%s'.
 SINGLE_EQUIJOIN_ONLY=Only a single equality condition is supported for joining tables from different collections. Please refer to the list of the supported features.

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
@@ -302,6 +302,7 @@ public class DocumentDbConnection extends Connection
                         SqlState.CONNECTION_EXCEPTION,
                         e,
                         SqlError.AUTHORIZATION_ERROR,
+                        mongoDatabase.getName(),
                         e.getCredential().getUserName(),
                         e.getCredential().getSource(),
                         e.getCredential().getMechanism());

--- a/src/markdown/support/troubleshooting-guide.md
+++ b/src/markdown/support/troubleshooting-guide.md
@@ -132,7 +132,7 @@ The online security resources may give a pointer how to fix this.
 ### Invalid username or password 
 
 #### What to look for: 
-- `Authorization failed for user '<username>' on database 'admin' with mechanism 'SCRAM-SHA-1'.`
+- `Invalid username or password or user is not authorized on database '<database>'. Please check your settings. Authorization failed for user '<username>' on database 'admin' with mechanism 'SCRAM-SHA-1'.`
 - `Exception authenticating MongoCredential{mechanism=SCRAM-SHA-1, userName='<username>', source='admin', password=<hidden>, mechanismProperties=<hidden>}'.`
 
 #### What to do: 


### PR DESCRIPTION
### Summary

[AD-387] Tableau: incorrect error message when connecting with wrong credentials.

### Description

Updated error text to include username, password and database.

### Related Issue

https:/bitquill.atlassian.net/browse/AD-387

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
