### PR TITLE
[AD-404] FIX: Loading JDBC driver in DbVisualizer can fail with IllegalArgumentException: URI is not hierarchical

### DIFF
--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -92,17 +92,17 @@ public class DocumentDbConnectionProperties extends Properties {
 
     private static String getClassPathLocation() {
         String classPathLocation = null;
-        try {
-            final Path classParentPath = Paths.get(DocumentDbConnectionProperties.class
-                    .getProtectionDomain()
-                    .getCodeSource()
-                    .getLocation()
-                    .toURI()).getParent();
-            if (classParentPath != null) {
-                classPathLocation = classParentPath.toString();
-            }
-        } catch (URISyntaxException e) {
-            // Ignore error, return null.
+        // Note: don't get the URI for this location URL. It will fail to be
+        // recognized by Path.get().
+        final String codeSourcePath = DocumentDbConnectionProperties.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .getPath();
+        final Path classPath = Paths.get(codeSourcePath);
+        final Path classParentPath = classPath.getParent();
+        if (classParentPath != null) {
+            classPathLocation = classParentPath.toString();
         }
         return classPathLocation;
     }
@@ -288,7 +288,7 @@ public class DocumentDbConnectionProperties extends Properties {
     /**
      * Get the timeout for opening a connection.
      *
-     * @return The connect timeout in seconds.
+     * @return The connection timeout in seconds.
      */
     public Integer getLoginTimeout() {
         return getPropertyAsInteger(DocumentDbConnectionProperty.LOGIN_TIMEOUT_SEC.getName());
@@ -297,7 +297,7 @@ public class DocumentDbConnectionProperties extends Properties {
     /**
      * Sets the timeout for opening a connection.
      *
-     * @param timeout The connect timeout in seconds.
+     * @param timeout The connection timeout in seconds.
      */
     public void setLoginTimeout(final String timeout) {
         setProperty(DocumentDbConnectionProperty.LOGIN_TIMEOUT_SEC.getName(), timeout);

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -57,30 +57,18 @@ public class DocumentDbConnectionProperties extends Properties {
 
     public static final String DOCUMENT_DB_SCHEME = "jdbc:documentdb:";
     public static final String USER_HOME_PROPERTY = "user.home";
-    public static final String USER_HOME_PATH_NAME;
-    public static final String DOCUMENTDB_HOME_PATH_NAME;
-    public static final String CLASS_PATH_LOCATION_NAME;
-    static final String[] SSH_PRIVATE_KEY_FILE_SEARCH_PATHS;
 
-    private static final Logger LOGGER;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentDbConnectionProperties.class.getName());
+    private static final String USER_HOME_PATH_NAME  = System.getProperty(USER_HOME_PROPERTY);
+    private static final String DOCUMENTDB_HOME_PATH_NAME = Paths.get(
+            USER_HOME_PATH_NAME, ".documentdb").toString();
     private static final String AUTHENTICATION_DATABASE = "admin";
     private static final Pattern WHITE_SPACE_PATTERN = Pattern.compile("^\\s*$");
     private static final String ROOT_PEM_RESOURCE_FILE_NAME = "/rds-ca-2019-root.pem";
     public static final String HOME_PATH_PREFIX_REG_EXPR = "^~[/\\\\].*$";
     public static final int FETCH_SIZE_DEFAULT = 2000;
-
-    static {
-        LOGGER = LoggerFactory.getLogger(DocumentDbConnectionProperties.class.getName());
-        USER_HOME_PATH_NAME = System.getProperty(USER_HOME_PROPERTY);
-        DOCUMENTDB_HOME_PATH_NAME = Paths.get(
-                USER_HOME_PATH_NAME, ".documentdb").toString();
-        CLASS_PATH_LOCATION_NAME = getClassPathLocation();
-        SSH_PRIVATE_KEY_FILE_SEARCH_PATHS = new String[] {
-                USER_HOME_PATH_NAME,
-                DOCUMENTDB_HOME_PATH_NAME,
-                CLASS_PATH_LOCATION_NAME,
-        };
-    }
+    private static String classPathLocationName = null;
+    private static String[] sshPrivateKeyFileSearchPaths = null;
 
     /**
      * Constructor for DocumentDbConnectionProperties, initializes with given properties.
@@ -97,6 +85,52 @@ public class DocumentDbConnectionProperties extends Properties {
      */
     public DocumentDbConnectionProperties() {
         super();
+    }
+
+    /**
+     * Gets the search paths when trying to locate the SSH private key file.
+     *
+     * @return an array of search paths.
+     */
+    static String[] getSshPrivateKeyFileSearchPaths() {
+        if (sshPrivateKeyFileSearchPaths == null) {
+            sshPrivateKeyFileSearchPaths = new String[]{
+                    USER_HOME_PATH_NAME,
+                    DOCUMENTDB_HOME_PATH_NAME,
+                    getClassPathLocation(),
+            };
+        }
+        return sshPrivateKeyFileSearchPaths;
+    }
+
+    /**
+     * Gets the user's home path name.
+     *
+     * @return the user's home path name.
+     */
+    static String getUserHomePathName() {
+        return USER_HOME_PATH_NAME;
+    }
+
+    /**
+     * Gets the ~/.documentdb path name.
+     *
+     * @return the ~/.documentdb path name.
+     */
+    static String getDocumentdbHomePathName() {
+        return DOCUMENTDB_HOME_PATH_NAME;
+    }
+
+    /**
+     * Gets the class path's location name.
+     *
+     * @return the class path's location name.
+     */
+    static String getClassPathLocationName() {
+        if (classPathLocationName == null) {
+            classPathLocationName = getClassPathLocation();
+        }
+        return classPathLocationName;
     }
 
     private static String getClassPathLocation() {
@@ -1028,7 +1062,7 @@ public class DocumentDbConnectionProperties extends Properties {
      * @return returns {@code true} if the file exists, {@code false}, otherwise.
      */
     public boolean isSshPrivateKeyFileExists() {
-        return Files.exists(getPath(getSshPrivateKeyFile(), SSH_PRIVATE_KEY_FILE_SEARCH_PATHS));
+        return Files.exists(getPath(getSshPrivateKeyFile(), getSshPrivateKeyFileSearchPaths()));
     }
 
     /**

--- a/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
@@ -33,12 +33,12 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
-import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.CLASS_PATH_LOCATION_NAME;
-import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.DOCUMENTDB_HOME_PATH_NAME;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.DOCUMENT_DB_SCHEME;
-import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.SSH_PRIVATE_KEY_FILE_SEARCH_PATHS;
-import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.USER_HOME_PATH_NAME;
+import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getClassPathLocationName;
+import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getDocumentdbHomePathName;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getPath;
+import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getSshPrivateKeyFileSearchPaths;
+import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getUserHomePathName;
 
 public class DocumentDbConnectionPropertiesTest {
 
@@ -282,15 +282,15 @@ public class DocumentDbConnectionPropertiesTest {
 
         // Test that it will use the user's home path
         final Path path2 = getPath("~/" + tempFilename1);
-        Assertions.assertEquals(Paths.get(USER_HOME_PATH_NAME, tempFilename1), path2);
+        Assertions.assertEquals(Paths.get(getUserHomePathName(), tempFilename1), path2);
 
         // Test that it will use the user's home path
         Path homeTempFilePath = null;
         try {
-            homeTempFilePath = Paths.get(USER_HOME_PATH_NAME, tempFilename1);
+            homeTempFilePath = Paths.get(getUserHomePathName(), tempFilename1);
             Assertions.assertTrue(homeTempFilePath.toFile().createNewFile());
-            final Path path3 = getPath(tempFilename1, SSH_PRIVATE_KEY_FILE_SEARCH_PATHS);
-            Assertions.assertEquals(Paths.get(USER_HOME_PATH_NAME, tempFilename1), path3);
+            final Path path3 = getPath(tempFilename1, getSshPrivateKeyFileSearchPaths());
+            Assertions.assertEquals(Paths.get(getUserHomePathName(), tempFilename1), path3);
         } finally {
             Assertions.assertTrue(homeTempFilePath != null && homeTempFilePath.toFile().delete());
         }
@@ -298,10 +298,10 @@ public class DocumentDbConnectionPropertiesTest {
         // Test that it will use the .documentdb folder under the user's home path
         Path documentDbTempFilePath = null;
         try {
-            documentDbTempFilePath = Paths.get(DOCUMENTDB_HOME_PATH_NAME, tempFilename1);
+            documentDbTempFilePath = Paths.get(getDocumentdbHomePathName(), tempFilename1);
             Assertions.assertTrue(documentDbTempFilePath.toFile().createNewFile());
-            final Path path4 = getPath(tempFilename1, SSH_PRIVATE_KEY_FILE_SEARCH_PATHS);
-            Assertions.assertEquals(Paths.get(DOCUMENTDB_HOME_PATH_NAME, tempFilename1), path4);
+            final Path path4 = getPath(tempFilename1, getSshPrivateKeyFileSearchPaths());
+            Assertions.assertEquals(Paths.get(getDocumentdbHomePathName(), tempFilename1), path4);
         } finally {
             Assertions.assertTrue(documentDbTempFilePath != null && documentDbTempFilePath.toFile().delete());
         }
@@ -309,10 +309,10 @@ public class DocumentDbConnectionPropertiesTest {
         // Test that it will use the .documentdb folder under the user's home path
         Path classPathParentTempFilePath = null;
         try {
-            classPathParentTempFilePath = Paths.get(CLASS_PATH_LOCATION_NAME, tempFilename1);
+            classPathParentTempFilePath = Paths.get(getClassPathLocationName(), tempFilename1);
             Assertions.assertTrue(classPathParentTempFilePath.toFile().createNewFile());
-            final Path path5 = getPath(tempFilename1, SSH_PRIVATE_KEY_FILE_SEARCH_PATHS);
-            Assertions.assertEquals(Paths.get(CLASS_PATH_LOCATION_NAME, tempFilename1), path5);
+            final Path path5 = getPath(tempFilename1, getSshPrivateKeyFileSearchPaths());
+            Assertions.assertEquals(Paths.get(getClassPathLocationName(), tempFilename1), path5);
         } finally {
             Assertions.assertTrue(classPathParentTempFilePath != null && classPathParentTempFilePath.toFile().delete());
         }

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnection.java
@@ -50,8 +50,8 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
 import java.util.concurrent.Executor;
 
-import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.SSH_PRIVATE_KEY_FILE_SEARCH_PATHS;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getPath;
+import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.getSshPrivateKeyFileSearchPaths;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperties.isNullOrWhitespace;
 import static software.amazon.documentdb.jdbc.DocumentDbConnectionProperty.REFRESH_SCHEMA;
 import static software.amazon.documentdb.jdbc.metadata.DocumentDbDatabaseSchemaMetadata.VERSION_LATEST_OR_NEW;
@@ -374,7 +374,7 @@ public class DocumentDbConnection extends Connection
             final DocumentDbConnectionProperties connectionProperties,
             final JSch jSch) throws JSchException {
         final String privateKeyFileName = getPath(connectionProperties.getSshPrivateKeyFile(),
-                SSH_PRIVATE_KEY_FILE_SEARCH_PATHS).toString();
+                getSshPrivateKeyFileSearchPaths()).toString();
         LOGGER.debug("SSH private key file resolved to '{}'.", privateKeyFileName);
         // If passPhrase protected, will need to provide this, too.
         final String passPhrase = !isNullOrWhitespace(connectionProperties.getSshPrivateKeyPassphrase())


### PR DESCRIPTION
### Summary

[AD-404] FIX: Loading JDBC driver in DbVisualizer can fail with `IllegalArgumentException: URI is not hierarchical`

### Description

Incompatibility between URI produced from source code location of the class and using `Path.get()` (in Windows/java 11).
- So used `URL.getPath()` instead.

### Related Issue

[https:/bitquill.atlassian.net/browse/AD-404](https:/bitquill.atlassian.net/browse/AD-404)

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
