### PR TITLE
[AD-282] Fix Inconsistency in Current_Time

### DIFF
--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbFilter.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbFilter.java
@@ -93,7 +93,8 @@ public class DocumentDbFilter extends Filter implements DocumentDbRel {
                                 getInput().getRowType(),
                                 mongoImplementor.getMetadataTable()),
                         getInput().getRowType().getFieldNames(),
-                        mongoImplementor.getMetadataTable());
+                        mongoImplementor.getMetadataTable(),
+                        implementor.getCurrentTime());
         final RexNode expandedCondition = RexUtil.expandSearch(implementor.getRexBuilder(), null, condition);
         final Operand match = expandedCondition.accept(rexToMongoTranslator);
 

--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbProject.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbProject.java
@@ -110,7 +110,8 @@ public class DocumentDbProject extends Project implements DocumentDbRel {
                         DocumentDbRules.mongoFieldNames(
                                 getInput().getRowType(),
                                 mongoImplementor.getMetadataTable()),
-                        inNames, mongoImplementor.getMetadataTable());
+                        inNames, mongoImplementor.getMetadataTable(),
+                        implementor.getCurrentTime());
         final List<String> items = new ArrayList<>();
         final LinkedHashMap<String, DocumentDbSchemaColumn> columnMap = new LinkedHashMap<>(implementor.getMetadataTable().getColumnMap());
         for (Pair<RexNode, String> pair : getNamedProjects()) {

--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbRel.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbRel.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.util.Pair;
 import software.amazon.documentdb.jdbc.metadata.DocumentDbSchemaTable;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,12 +51,13 @@ public interface DocumentDbRel extends RelNode {
         private RelOptTable table;
         private DocumentDbSchemaTable metadataTable;
         private DocumentDbTable documentDbTable;
-        private List<String> unwinds = new ArrayList<>();
-        private List<String> collisionResolutions = new ArrayList<>();
+        private final List<String> unwinds = new ArrayList<>();
+        private final List<String> collisionResolutions = new ArrayList<>();
         private String virtualTableFilter;
         private boolean nullFiltered = false;
         private boolean join = false;
         private boolean resolutionNeedsUnwind = false;
+        private final Instant currentTime = Instant.now();
 
         // DocumentDB: modified - end
 
@@ -163,6 +165,10 @@ public interface DocumentDbRel extends RelNode {
             final boolean isJoin = isJoin();
             ((DocumentDbRel) input).implement(this);
             setJoin(isJoin);
+        }
+
+        public Instant getCurrentTime() {
+            return currentTime;
         }
     }
 }

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceDateTimeTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingServiceDateTimeTest.java
@@ -18,16 +18,12 @@ package software.amazon.documentdb.jdbc.query;
 
 import com.mongodb.client.MongoClient;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.bson.BsonArray;
 import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
-import org.bson.BsonInt64;
-import org.bson.BsonString;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -693,7 +689,6 @@ public class DocumentDbQueryMappingServiceDateTimeTest extends DocumentDbFlapDoo
     }
 
     @Test
-    @Disabled("AD-282: Slight disparity in current time due to repeated determination of time.")
     @DisplayName("Tests CURRENT_DATE in WHERE clause.")
     void testWhereCurrentDate() throws SQLException {
         final String dayNameQuery =
@@ -703,26 +698,28 @@ public class DocumentDbQueryMappingServiceDateTimeTest extends DocumentDbFlapDoo
         final DocumentDbMqlQueryContext context = queryMapper.get(dayNameQuery);
         Assertions.assertNotNull(context);
         final List<Bson> operations = context.getAggregateOperations();
-        Assertions.assertEquals(3, operations.size());
+        Assertions.assertEquals(4, operations.size());
         final BsonDocument rootDoc = context.getAggregateOperations()
                 .get(0).toBsonDocument(BsonDocument.class, null);
         Assertions.assertNotNull(rootDoc);
-        final BsonDocument addFieldsDoc = rootDoc.getDocument("$addFields");
+        final BsonDocument addFieldsDoc = rootDoc.getDocument("$project");
         Assertions.assertNotNull(addFieldsDoc);
         final BsonDateTime cstDateTime = addFieldsDoc.getDocument(DocumentDbFilter.BOOLEAN_FLAG_FIELD.substring(1, DocumentDbFilter.BOOLEAN_FLAG_FIELD.length() - 1))
-                .getArray("$and").get(0).asDocument().getArray("$ne").get(1).asDateTime();
+                .getArray("$cond").get(1).asDocument()
+                .getArray("$ne").get(1).asDateTime();
         Assertions.assertNotNull(cstDateTime);
         Assertions.assertEquals(BsonDocument.parse(
-                "{\"$addFields\": { " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": " +
-                        "{\"$and\": [{\"$ne\": [\"$field\", {\"$date\": " + cstDateTime.getValue() + "}]}, {\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": " + cstDateTime.getValue() + "}, null]}]}}}"), operations.get(0));
+                "{\"$project\": {\"_id\": 1, \"field\": 1, " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$cond\": [{\"$and\": [{\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}, null]}]}, {\"$ne\": [\"$field\", {\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}]}, null]}}}"),
+                operations.get(0));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$match\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$eq\": true}}}"), operations.get(1));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$project\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": 0}}"), operations.get(2));
+        Assertions.assertEquals(BsonDocument.parse(
+                "{\"$project\": {\"dateTestCollection__id\": \"$_id\", \"field\": \"$field\", \"_id\": 0}}"), operations.get(3));
     }
 
     @Test
-    @Disabled("AD-282: Slight disparity in current time due to repeated determination of time.")
     @DisplayName("Tests CURRENT_TIME in WHERE clause.")
     void testWhereCurrentTime() throws SQLException {
         final String dayNameQuery =
@@ -732,27 +729,28 @@ public class DocumentDbQueryMappingServiceDateTimeTest extends DocumentDbFlapDoo
         final DocumentDbMqlQueryContext context = queryMapper.get(dayNameQuery);
         Assertions.assertNotNull(context);
         final List<Bson> operations = context.getAggregateOperations();
-        Assertions.assertEquals(3, operations.size());
+        Assertions.assertEquals(4, operations.size());
         final BsonDocument rootDoc = context.getAggregateOperations()
                 .get(0).toBsonDocument(BsonDocument.class, null);
         Assertions.assertNotNull(rootDoc);
-        final BsonDocument addFieldsDoc = rootDoc.getDocument("$addFields");
+        final BsonDocument addFieldsDoc = rootDoc.getDocument("$project");
         Assertions.assertNotNull(addFieldsDoc);
         final BsonDateTime cstDateTime = addFieldsDoc.getDocument(DocumentDbFilter.BOOLEAN_FLAG_FIELD.substring(1, DocumentDbFilter.BOOLEAN_FLAG_FIELD.length() - 1))
-                .getArray("$and").get(0).asDocument().getArray("$ne").get(1).asDateTime();
+                .getArray("$cond").get(1).asDocument()
+                .getArray("$ne").get(1).asDateTime();
         Assertions.assertNotNull(cstDateTime);
         Assertions.assertEquals(BsonDocument.parse(
-                "{\"$addFields\": { " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": " +
-                        "{\"$and\": [{\"$ne\": [\"$field\", {\"$date\": " + cstDateTime.getValue() + "}]}, " +
-                        "{\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": " + cstDateTime.getValue() + "}, null]}]}}}"), operations.get(0));
+                "{\"$project\": {\"_id\": 1, \"field\": 1, " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$cond\": [{\"$and\": [{\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}, null]}]}, {\"$ne\": [\"$field\", {\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}]}, null]}}}"),
+                operations.get(0));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$match\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$eq\": true}}}"), operations.get(1));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$project\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": 0}}"), operations.get(2));
+        Assertions.assertEquals(BsonDocument.parse(
+                "{\"$project\": {\"dateTestCollection__id\": \"$_id\", \"field\": \"$field\", \"_id\": 0}}"), operations.get(3));
     }
 
     @Test
-    @Disabled("AD-282: Slight disparity in current time due to repeated determination of time.")
     @DisplayName("Tests CURRENT_TIMESTAMP in WHERE clause.")
     void testWhereCurrentTimestamp() throws SQLException {
         final String dayNameQuery =
@@ -762,23 +760,28 @@ public class DocumentDbQueryMappingServiceDateTimeTest extends DocumentDbFlapDoo
         final DocumentDbMqlQueryContext context = queryMapper.get(dayNameQuery);
         Assertions.assertNotNull(context);
         final List<Bson> operations = context.getAggregateOperations();
-        Assertions.assertEquals(3, operations.size());
+        Assertions.assertEquals(4, operations.size());
         final BsonDocument rootDoc = context.getAggregateOperations()
                 .get(0).toBsonDocument(BsonDocument.class, null);
         Assertions.assertNotNull(rootDoc);
-        final BsonDocument addFieldsDoc = rootDoc.getDocument("$addFields");
-        Assertions.assertNotNull(addFieldsDoc);
-        final BsonDateTime cstDateTime = addFieldsDoc.getDocument(DocumentDbFilter.BOOLEAN_FLAG_FIELD.substring(1, DocumentDbFilter.BOOLEAN_FLAG_FIELD.length() - 1))
-                .getArray("$and").get(0).asDocument().getArray("$ne").get(1).asDateTime();
+        final BsonDocument project = rootDoc.getDocument("$project");
+        Assertions.assertNotNull(project);
+        final BsonDateTime cstDateTime = project.getDocument(
+                DocumentDbFilter.BOOLEAN_FLAG_FIELD.substring(1,
+                        DocumentDbFilter.BOOLEAN_FLAG_FIELD.length() - 1))
+                .getArray("$cond").get(0).asDocument()
+                .getArray("$and").get(1).asDocument()
+                .getArray("$gt").get(0).asDateTime();
         Assertions.assertNotNull(cstDateTime);
         Assertions.assertEquals(BsonDocument.parse(
-                "{\"$addFields\": { " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": " +
-                        "{\"$and\": [{\"$ne\": [\"$field\", {\"$date\": " + cstDateTime.getValue() + "}]}, " +
-                        "{\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": " + cstDateTime.getValue() + "}, null]}]}}}"), operations.get(0));
+                "{\"$project\": {\"_id\": 1, \"field\": 1, " + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$cond\": [{\"$and\": [{\"$gt\": [\"$field\", null]}, {\"$gt\": [{\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}, null]}]}, {\"$ne\": [\"$field\", {\"$date\": {\"$numberLong\": \"" + cstDateTime.getValue() + "\"}}]}, null]}}}"),
+                operations.get(0));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$match\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": {\"$eq\": true}}}"), operations.get(1));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$project\": {" + DocumentDbFilter.BOOLEAN_FLAG_FIELD + ": 0}}"), operations.get(2));
+        Assertions.assertEquals(BsonDocument.parse(
+                "{\"$project\": {\"dateTestCollection__id\": \"$_id\", \"field\": \"$field\", \"_id\": 0}}"), operations.get(3));
     }
 
     @Test
@@ -793,9 +796,6 @@ public class DocumentDbQueryMappingServiceDateTimeTest extends DocumentDbFlapDoo
         Assertions.assertNotNull(context);
         final List<Bson> operations = context.getAggregateOperations();
         Assertions.assertEquals(4, operations.size());
-        final BsonArray array = new BsonArray();
-        array.add(new BsonDocument("$year", new BsonString("$field")));
-        array.add(new BsonInt64(2021));
         Assertions.assertEquals(BsonDocument.parse(
                 "{\"$project\": {"
                         + "\"_id\": 1, "

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementDateTimeTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementDateTimeTest.java
@@ -1108,6 +1108,50 @@ public class DocumentDbStatementDateTimeTest extends DocumentDbStatementTest {
         }
     }
 
+    /**
+     * Tests CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE for multiple instances are the same value.
+     * 
+     * @throws SQLException occurs if query fails.
+     */
+    @DisplayName("Tests CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE for multiple instances are the same value.")
+    @ParameterizedTest(name = "testCurrentTimestampMultipleInstances - [{index}] - {arguments}")
+    @MethodSource({"getTestEnvironments"})
+    void testCurrentTimestampMultipleInstances(final DocumentDbTestEnvironment testEnvironment) throws SQLException {
+        setTestEnvironment(testEnvironment);
+        final String tableName = "testCurrentTimestampMultipleInstances";
+        final long dateTime = Instant.parse("2020-02-03T04:05:06.00Z").toEpochMilli();
+        final BsonDocument doc1 = BsonDocument.parse("{\"_id\": 101}");
+        doc1.append("field", new BsonDateTime(dateTime));
+        insertBsonDocuments(tableName, new BsonDocument[]{doc1});
+        try (Connection connection = getConnection()) {
+            final Statement statement = getDocumentDbStatement(connection);
+
+            // Get current date.
+            final ResultSet resultSet1 = statement.executeQuery(
+                    String.format(
+                            "SELECT CURRENT_TIMESTAMP AS ts, CURRENT_TIME AS t, CURRENT_DATE AS d"
+                                    + " FROM \"%s\".\"%s\"", getDatabaseName(), tableName));
+
+            Assertions.assertNotNull(resultSet1);
+            Assertions.assertTrue(resultSet1.next());
+            Assertions.assertEquals(Types.TIMESTAMP,
+                    resultSet1.getMetaData().getColumnType(1));
+            Assertions.assertEquals(Types.TIME,
+                    resultSet1.getMetaData().getColumnType(2));
+            Assertions.assertEquals(Types.DATE,
+                    resultSet1.getMetaData().getColumnType(3));
+            final Timestamp timestamp = resultSet1.getTimestamp(1);
+            final Timestamp time = resultSet1.getTimestamp(2);
+            final Timestamp date = resultSet1.getTimestamp(3);
+            Assertions.assertNotNull(timestamp);
+            Assertions.assertNotNull(time);
+            Assertions.assertNotNull(date);
+            Assertions.assertEquals(timestamp, time);
+            Assertions.assertEquals(timestamp, date);
+            Assertions.assertFalse(resultSet1.next());
+        }
+    }
+
     private long getTruncatedTimestamp(final OffsetDateTime offsetDateTime, final int monthValue) {
         return OffsetDateTime.of(
                 offsetDateTime.getYear(), monthValue, 1,

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementDateTimeTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbStatementDateTimeTest.java
@@ -1110,7 +1110,7 @@ public class DocumentDbStatementDateTimeTest extends DocumentDbStatementTest {
 
     /**
      * Tests CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE for multiple instances are the same value.
-     * 
+     *
      * @throws SQLException occurs if query fails.
      */
     @DisplayName("Tests CURRENT_TIMESTAMP, CURRENT_TIME and CURRENT_DATE for multiple instances are the same value.")


### PR DESCRIPTION
### Summary

[AD-282] Fix Inconsistency in Current_Time

### Description

- Initialize an "Instant" with the current time and pass it to the Filter/Project that in turn passes it to he Translator.
- Add a new test
- Re-enable previously disabled tests.

### Related Issue

https:/bitquill.atlassian.net/browse/AD-282

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
