### PR TITLE
[AD-433] Add in Contribution Guide how to ask questions using GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report an issue for the AWS DocumentDB JDBC Driver project.
+title: "[BUG]"
+labels: 'bug'
+assignees: ''
+
+---
+
+##Environment
+- DocumentDB JDBC driver version:
+- DocumentDB server version:
+- OS: [e.g. MacOS Big Sur 11.5.1, Windows 10 64-bit]
+- BI Tool or client name: 
+- BI Tool or client version:
+- Java version (if known): 
+
+---
+
+##Problem Description
+1. Steps to reproduce:
+2. Expected behaviour:
+3. Actual behaviour:
+4. Error message/stack trace:
+5. Any other details that can be helpful:
+
+---
+
+##Screenshots
+- If applicable, add screenshots to help explain your problem.
+
+---
+
+##JDBC log
+- Add related JDBC log entries here.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for the DocumentDB JDBC Driver project.
+title: '[FEATURE]'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+##Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+##Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+##Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+##Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,3 @@
 @andiem-bq
 @alexey-temnikov
 @birschick-bq
-@mitchell-elholm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/aws/amazon-documentdb-jdbc-driver/issues),
+or [recently closed](https://github.com/aws/amazon-documentdb-jdbc-driver/issues?q=is%3Aissue+is%3Aclosed), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps


### PR DESCRIPTION
### Summary

[AD-433] Add in Contribution Guide how to ask questions using GitHub Issues

### Description

Added:
- bug and feature templates.
- links to the open and closed issues page.
- removed Mitchell from the PR template.

### Related Issue

https:/bitquill.atlassian.net/browse/AD-433

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
@mitchell-elholm
