### PR TITLE
Increased retention policy to 10 days

### DIFF
--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Remove Old Artifacts
       uses: c-hive/gha-remove-artifacts@v1
       with:
-        age: '1 day'
+        age: '10 day'
         # skip-tags will prevent tags (i.e releases) from being deleted.
         skip-tags: true


### PR DESCRIPTION
### Summary
Currently retention period is 1 day, increasing it for 10 days, so it is possible to efficiently download build artifacts for older PRs.

### Related Issue
AD-452

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
