### PR TITLE
[AD-455] Update port number used + name of jar

### DIFF
--- a/src/markdown/schema/manage-schema-cli.md
+++ b/src/markdown/schema/manage-schema-cli.md
@@ -58,11 +58,16 @@ The miscellaneous options provide more information about this interface.
 
 ## Examples
 
+The examples below are for a user `ajones` connecting to the database `test` 
+using version `1.0.0` of the driver (`documentdb-jdbc-1.0.0-all.jar`) 
+on their local machine with port forwarding on `localhost:27017` to a DocumentDB cluster 
+which is TLS-enabled.
+
 ### Generate Schema using Default Schema Name
 
 ```
-> java -jar document-db-1.0.0-all.jar --generate-new \
-        --server localhost:27019 --database test -u ajones --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --generate-new \
+        --server localhost:27017 --database test -u ajones --tls --tls-allow-invalid-hostnames
 Password:
 
 New schema '_default', version '1' generated.
@@ -71,8 +76,8 @@ New schema '_default', version '1' generated.
 ### Generate Schema using Custom Schema Name
 
 ```
-> java -jar document-db-1.0.0-all.jar --generate-new --schema-name=products \
-        --server localhost:27019 --database test -u ajones --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --generate-new --schema-name=products \
+        --server localhost:27017 --database test -u ajones --tls --tls-allow-invalid-hostnames
 Password:
 
 New schema 'products', version '1' generated.
@@ -80,8 +85,8 @@ New schema 'products', version '1' generated.
 
 ### Removing Custom Schema
 ```
-> java -jar document-db-1.0.0-all.jar --remove --schema-name=products \
-        --server localhost:27019 --database test -u ajones --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --remove --schema-name=products \
+        --server localhost:27017 --database test -u ajones --tls --tls-allow-invalid-hostnames
 Password:
 
 Removed schema 'products'.
@@ -90,8 +95,8 @@ Removed schema 'products'.
 ### Password as Option
 
 ```
-> java -jar document-db-1.0.0-all.jar --generate-new \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --generate-new \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 
 New schema '_default', version '2' generated.
 ```
@@ -99,8 +104,8 @@ New schema '_default', version '2' generated.
 ### Listing Schema
 
 ```
-> java -jar document-db-1.0.0-all.jar --list-schema \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --list-schema \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 
 Name=_default, Version=1, SQL Name=test, Modified=2021-06-01T10:35:08-07:00
 ```
@@ -108,8 +113,8 @@ Name=_default, Version=1, SQL Name=test, Modified=2021-06-01T10:35:08-07:00
 ### Listing Table Schema
 
 ```
-> java -jar document-db-1.0.0-all.jar --list-tables \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --list-tables \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 
 products
 products_additional_tarriffs
@@ -125,8 +130,8 @@ projects
 ### Exporting Schema to Stdout
 
 ```
-> java -jar document-db-1.0.0-all.jar --export=products,products_for \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --export=products,products_for \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 
 [ {
   sqlName : products,
@@ -152,8 +157,8 @@ projects
 ### Exporting Schema to File
 
 ```
-> java -jar document-db-1.0.0-all.jar --export=products,products_for -o "sql-schema.json" \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --export=products,products_for -o "sql-schema.json" \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 > cd ~
 > cat sql-schema.json
 [ {
@@ -180,6 +185,6 @@ projects
 ### Importing Schema
 
 ```
-> java -jar document-db-1.0.0-all.jar --import=sql-schema.json \
-        --server localhost:27019 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
+> java -jar documentdb-jdbc-1.0.0-all.jar --import=sql-schema.json \
+        --server localhost:27017 --database test -u ajones -p secret --tls --tls-allow-invalid-hostnames
 ```


### PR DESCRIPTION
### Summary
- Small updates to schema CLI documentation

### Description
- Updated name of jar used in CLI examples to documentdb-jdbc-version-all.jar
- Updated port used from 27019 to 27017 but added description at the top

### Related Issue
https://bitquill.atlassian.net/browse/AD-455

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
