### PR TITLE
Add space between titles and # in feature/bug templates to correct formatting on github

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-##Environment
+## Environment
 - DocumentDB JDBC driver version:
 - DocumentDB server version:
 - OS: [e.g. MacOS Big Sur 11.5.1, Windows 10 64-bit]
@@ -17,7 +17,7 @@ assignees: ''
 
 ---
 
-##Problem Description
+## Problem Description
 1. Steps to reproduce:
 2. Expected behaviour:
 3. Actual behaviour:
@@ -26,10 +26,10 @@ assignees: ''
 
 ---
 
-##Screenshots
+## Screenshots
 - If applicable, add screenshots to help explain your problem.
 
 ---
 
-##JDBC log
+## JDBC log
 - Add related JDBC log entries here.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -7,18 +7,18 @@ assignees: ''
 
 ---
 
-##Is your feature request related to a problem? Please describe.
+## Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-##Describe the solution you'd like
+## Describe the solution you'd like
 
 A clear and concise description of what you want to happen.
 
-##Describe alternatives you've considered
+## Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-##Additional context
+## Additional context
 
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Summary

- Headers were not being recognized when displayed on GitHub. Added space.

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
