### PR TITLE
[AD-499] Add default application name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -265,13 +265,21 @@ license {
 }
 
 /**
- * Write driver version data to properties file.
+ * Write driver version data to properties file under base project.
  */
 task writeProperties(type: WriteProperties) {
     outputFile("$projectDir/src/main/resources/project.properties")
     property("driver.major.version", MAJOR_VERSION)
     property("driver.minor.version", MINOR_VERSION)
     property("driver.full.version", project.version)
+}
+
+/**
+ * Write default application name to properties file under common.
+ */
+task writeCommonProperties(type: WriteProperties) {
+    outputFile("$projectDir/common/src/main/resources/common.properties")
+    property("default.application.name", "${APPLICATION_NAME} v${project.version}")
 }
 
 processResources {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -170,7 +170,7 @@ jacocoTestCoverageVerification.dependsOn jacocoTestReport
  */
 license {
     header =  project.parent.file('license-header.txt')
-    exclude "**/log4j.properties"
+    excludes(["**/log4j.properties", "common.properties"])
     headerDefinitions {
         slash_star_with_space {
             firstLine = '/*'

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -239,7 +239,9 @@ public class DocumentDbConnectionProperties extends Properties {
      * @return The name of the application.
      */
     public String getApplicationName() {
-        return getProperty(DocumentDbConnectionProperty.APPLICATION_NAME.getName());
+        return getProperty(
+                DocumentDbConnectionProperty.APPLICATION_NAME.getName(),
+                DocumentDbConnectionProperty.APPLICATION_NAME.getDefaultValue());
     }
 
     /**

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -69,6 +69,21 @@ public class DocumentDbConnectionProperties extends Properties {
     public static final int FETCH_SIZE_DEFAULT = 2000;
     private static String classPathLocationName = null;
     private static String[] sshPrivateKeyFileSearchPaths = null;
+    private static final String DEFAULT_APPLICATION_NAME_KEY = "default.application.name";
+    private static final String PROPERTIES_FILE_PATH = "/common.properties";
+    static final String DEFAULT_APPLICATION_NAME;
+
+    static {
+        String defaultAppName = "";
+        try (InputStream is = DocumentDbConnectionProperties.class.getResourceAsStream(PROPERTIES_FILE_PATH)) {
+            final Properties p = new Properties();
+            p.load(is);
+            defaultAppName = p.getProperty(DEFAULT_APPLICATION_NAME_KEY);
+        } catch (Exception e) {
+            LOGGER.error("Error loading default application name: " + e.getMessage());
+        }
+        DEFAULT_APPLICATION_NAME = defaultAppName;
+    }
 
     /**
      * Constructor for DocumentDbConnectionProperties, initializes with given properties.
@@ -241,7 +256,7 @@ public class DocumentDbConnectionProperties extends Properties {
     public String getApplicationName() {
         return getProperty(
                 DocumentDbConnectionProperty.APPLICATION_NAME.getName(),
-                DocumentDbConnectionProperty.APPLICATION_NAME.getDefaultValue());
+                DocumentDbConnectionProperty.APPLICATION_NAME.getDefaultValue() );
     }
 
     /**

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -743,7 +743,8 @@ public class DocumentDbConnectionProperties extends Properties {
         final String hostInfo = isNullOrWhitespace(getHostname()) ? "" : getHostname();
         final String databaseInfo = isNullOrWhitespace(getDatabase()) ? "" : getDatabase();
         final StringBuilder optionalInfo = new StringBuilder();
-        if (getApplicationName() != null) {
+        if (!getApplicationName()
+                .equals(DocumentDbConnectionProperty.APPLICATION_NAME.getDefaultValue())) {
             appendOption(optionalInfo, DocumentDbConnectionProperty.APPLICATION_NAME, getApplicationName());
         }
         if (getLoginTimeout() != Integer.parseInt(DocumentDbConnectionProperty.LOGIN_TIMEOUT_SEC.getDefaultValue())) {

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperty.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperty.java
@@ -33,7 +33,7 @@ public enum DocumentDbConnectionProperty implements ConnectionProperty {
             "The name of the database to connect to in DocumentDB."),
     READ_PREFERENCE("readPreference", "primary",
             "The read preference"),
-    APPLICATION_NAME(ConnectionProperty.APPLICATION_NAME, "Amazon DocumentDB JDBC Driver",
+    APPLICATION_NAME(ConnectionProperty.APPLICATION_NAME, DocumentDbConnectionProperties.DEFAULT_APPLICATION_NAME,
             "Sets the logical name of the application. The application name may be used by the client to identify the application to the server, for use in server logs, slow query logs, and profile collection."),
     REPLICA_SET("replicaSet", "rs0",
             "Implies that the hosts given are a seed list, and the driver will attempt to find all members of the set."),

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperty.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperty.java
@@ -33,7 +33,7 @@ public enum DocumentDbConnectionProperty implements ConnectionProperty {
             "The name of the database to connect to in DocumentDB."),
     READ_PREFERENCE("readPreference", "primary",
             "The read preference"),
-    APPLICATION_NAME(ConnectionProperty.APPLICATION_NAME, "",
+    APPLICATION_NAME(ConnectionProperty.APPLICATION_NAME, "Amazon DocumentDB JDBC Driver",
             "Sets the logical name of the application. The application name may be used by the client to identify the application to the server, for use in server logs, slow query logs, and profile collection."),
     REPLICA_SET("replicaSet", "rs0",
             "Implies that the hosts given are a seed list, and the driver will attempt to find all members of the set."),

--- a/common/src/main/resources/common.properties
+++ b/common/src/main/resources/common.properties
@@ -1,0 +1,1 @@
+default.application.name=Amazon DocumentDB JDBC Driver v1.0.1

--- a/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
@@ -327,4 +327,24 @@ public class DocumentDbConnectionPropertiesTest {
             Assertions.assertTrue(tempFile != null && tempFile.delete());
         }
     }
+
+    /**
+     * Tests getting and setting the application name.
+     */
+    @Test
+    @DisplayName("Tests retrieving default and overridden application name and that the name is used in client settings.")
+    public void testApplicationName() throws SQLException {
+        // Get default app name.
+        final Properties info = new Properties();
+        final String connectionString = "jdbc:documentdb://username:password@localhost/database";
+        final DocumentDbConnectionProperties properties = DocumentDbConnectionProperties
+                .getPropertiesFromConnectionString(info, connectionString, DOCUMENT_DB_SCHEME);
+        Assertions.assertEquals("Amazon DocumentDB JDBC Driver", properties.getApplicationName());
+        // Override app name.
+        properties.setApplicationName("APPNAME");
+        Assertions.assertEquals("APPNAME", properties.getApplicationName());
+        // Build client settings and ensure app name is passed.
+        final MongoClientSettings settings = properties.buildMongoClientSettings();
+        Assertions.assertEquals("APPNAME", settings.getApplicationName());
+    }
 }

--- a/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
+++ b/common/src/test/java/software/amazon/documentdb/jdbc/DocumentDbConnectionPropertiesTest.java
@@ -16,6 +16,7 @@
 
 package software.amazon.documentdb.jdbc;
 
+import com.google.common.base.Strings;
 import com.mongodb.MongoClientSettings;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Assertions;
@@ -339,7 +340,8 @@ public class DocumentDbConnectionPropertiesTest {
         final String connectionString = "jdbc:documentdb://username:password@localhost/database";
         final DocumentDbConnectionProperties properties = DocumentDbConnectionProperties
                 .getPropertiesFromConnectionString(info, connectionString, DOCUMENT_DB_SCHEME);
-        Assertions.assertEquals("Amazon DocumentDB JDBC Driver", properties.getApplicationName());
+        Assertions.assertFalse(Strings.isNullOrEmpty(properties.getApplicationName()));
+        Assertions.assertEquals(DocumentDbConnectionProperties.DEFAULT_APPLICATION_NAME, properties.getApplicationName());
         // Override app name.
         properties.setApplicationName("APPNAME");
         Assertions.assertEquals("APPNAME", properties.getApplicationName());

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ CONNECTION_STRING_REMOTE=jdbc:documentdb://username:password@remotehost/database
 MAJOR_VERSION=1
 MINOR_VERSION=0
 PATCH_VERSION=1
+APPLICATION_NAME=Amazon DocumentDB JDBC Driver
 # Comment out if not creating a beta version
 #BETA_VERSION=1
 # Uncomment out next line to disable remote integration tests

--- a/src/markdown/setup/connection-string.md
+++ b/src/markdown/setup/connection-string.md
@@ -18,7 +18,7 @@
 ### Options
 | Option | Description | Default |
 |--------|-------------|---------------|
-| `appName` | (string) Sets the logical name of the application. | `NONE`
+| `appName` | (string) Sets the logical name of the application. | `Amazon DocumentDB JDBC Driver`
 | `loginTimeoutSec` | (int) How long a connection can take to be opened before timing out (in seconds). Alias for connectTimeoutMS but using seconds. | `NONE`
 | `readPreference` | (enum/string) The read preference for this connection. Allowed values: `primary`, `primaryPreferred`, `secondary`, `secondaryPreferred` or `nearest`. | `primary`
 | `replicaSet` | (string) Name of replica set to connect to. For now, passing a name other than `rs0` will log a warning. | `NONE`

--- a/src/markdown/setup/connection-string.md
+++ b/src/markdown/setup/connection-string.md
@@ -18,7 +18,7 @@
 ### Options
 | Option | Description | Default |
 |--------|-------------|---------------|
-| `appName` | (string) Sets the logical name of the application. | `Amazon DocumentDB JDBC Driver`
+| `appName` | (string) Sets the logical name of the application. | `Amazon DocumentDB JDBC Driver {version}`
 | `loginTimeoutSec` | (int) How long a connection can take to be opened before timing out (in seconds). Alias for connectTimeoutMS but using seconds. | `NONE`
 | `readPreference` | (enum/string) The read preference for this connection. Allowed values: `primary`, `primaryPreferred`, `secondary`, `secondaryPreferred` or `nearest`. | `primary`
 | `replicaSet` | (string) Name of replica set to connect to. For now, passing a name other than `rs0` will log a warning. | `NONE`


### PR DESCRIPTION
### Summary
- Added "Amazon DocumentDB JDBC Driver {version}" as the default application name. Example: Amazon DocumentDB JDBC Driver v1.0.1

### Description  
- Added task to determine full app name and write to properties file
- Added default value for `appName`
- Added test 
- Updated connection string documentation

### Related Issue
https://bitquill.atlassian.net/browse/AD-499

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
