### PR TITLE
[AD-512] Update flapdoodle usage to remove usage of deprecated components after upgrade of library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ dependencies {
     testCompileOnly         group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1'
     testCompileOnly         group: 'org.projectlombok', name: 'lombok', version: '1.18.16'
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.16'
-    testImplementation      group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.5'
+    testImplementation      group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.6'
     testImplementation      group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation      group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.1'
     testImplementation      group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.8.2'

--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ dependencies {
     testCompileOnly         group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1'
     testCompileOnly         group: 'org.projectlombok', name: 'lombok', version: '1.18.16'
     testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.16'
-    testImplementation      group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.4'
+    testImplementation      group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.5'
     testImplementation      group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation      group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.8.1'
     testImplementation      group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.8.2'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -206,7 +206,7 @@ dependencies {
     testCompileOnly    group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1'
 
     testFixturesImplementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    testFixturesImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.4'
+    testFixturesImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.5'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testFixturesImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.1.1'
     testFixturesImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -206,7 +206,7 @@ dependencies {
     testCompileOnly    group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1'
 
     testFixturesImplementation group: 'com.google.guava', name: 'guava', version: '29.0-jre'
-    testFixturesImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.5'
+    testFixturesImplementation group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: '3.2.6'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testFixturesImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.1.1'
     testFixturesImplementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'

--- a/common/src/testFixtures/java/software/amazon/documentdb/jdbc/common/test/DocumentDbMongoTestEnvironment.java
+++ b/common/src/testFixtures/java/software/amazon/documentdb/jdbc/common/test/DocumentDbMongoTestEnvironment.java
@@ -30,7 +30,7 @@ import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version.Main;
 import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
+import de.flapdoodle.embed.process.config.process.ProcessOutput;
 import de.flapdoodle.embed.process.io.LogWatchStreamProcessor;
 import de.flapdoodle.embed.process.io.NamedOutputStreamProcessor;
 import de.flapdoodle.embed.process.io.Processors;
@@ -107,7 +107,7 @@ public class DocumentDbMongoTestEnvironment extends DocumentDbAbstractTestEnviro
             return false;
         }
 
-        port = Network.getFreeServerPort();
+        port = Network.freeServerPort(Network.getLocalHost());
         final MongoCmdOptions cmdOptions = MongoCmdOptions.builder()
                 .auth(enableAuthentication)
                 .build();
@@ -226,10 +226,11 @@ public class DocumentDbMongoTestEnvironment extends DocumentDbAbstractTestEnviro
             mongoOutput = new NamedOutputStreamProcessor("[mongo shell output]", Processors.console());
         }
         final RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.Mongo)
-                .processOutput(new ProcessOutput(
-                        mongoOutput,
-                        namedConsole("[mongo shell error]"),
-                        Processors.console()))
+                .processOutput(ProcessOutput.builder()
+                        .output(mongoOutput)
+                        .error(Processors.namedConsole("[mongo shell error]"))
+                        .commands(Processors.console())
+                        .build())
                 .build();
         final MongoShellStarter starter = MongoShellStarter.getInstance(runtimeConfig);
         final File scriptFile = writeTmpScriptFile(scriptText);


### PR DESCRIPTION
### Summary

[AD-512] Update flapdoodle usage to remove usage of deprecated components after upgrade of library.

### Description

* Remove deprecated calls.

### Related Issue

https://bitquill.atlassian.net/browse/AD-512

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
