### PR TITLE
Add PR repository to checkout action + use pull_request_target event instead of pull_request

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,8 +48,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: ${{ github.event.pull_request_target.head.repo.full_name }}
-        ref: ${{ github.event.pull_request_target.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,7 +48,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request_target.head.repo.full_name }}
+        ref: ${{ github.event.pull_request_target.head.ref }}
         fetch-depth: 0
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ name: Amazon DocumentDB JDBC Driver
 on:
   # Trigger the workflow on pull request,
   # but only for the master/develop branches
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - develop
@@ -48,7 +48,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
     - name: Set up JDK 1.8

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,6 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
     - name: Set up JDK 1.8


### PR DESCRIPTION
### Summary

- Adjust checkout action to checkout from repository of PR
- Use pull_request_target to give access to base repository secrets 

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
