### PR TITLE
[AD-627] Add new method to get aggregate operations as strings

### DIFF
--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContext.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContext.java
@@ -48,10 +48,8 @@ public class DocumentDbMqlQueryContext {
      */
     public List<String> getAggregateOperationsAsStrings() {
         return aggregateOperations.stream()
-                .map(
-                        doc ->
-                                doc.toBsonDocument()
-                                        .toJson(JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build()))
+                .map(doc ->
+                        doc.toBsonDocument().toJson(JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build()))
                 .collect(Collectors.toList());
     }
 }

--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContext.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContext.java
@@ -19,12 +19,14 @@ package software.amazon.documentdb.jdbc.query;
 import lombok.Builder;
 import lombok.Getter;
 import org.bson.conversions.Bson;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 import software.amazon.documentdb.jdbc.common.utilities.JdbcColumnMetaData;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
- * This is meant to carry
- * all the information needed to execute the query in MongoDb and
+ * This is meant to carry all the information needed to execute the query in DocumentDB and
  * construct a ResultSet.
  */
 @Getter
@@ -38,4 +40,18 @@ public class DocumentDbMqlQueryContext {
     private final String collectionName;
     /** The path information for the output documents. Maps column names to field paths.*/
     private final List<String> paths;
+
+    /**
+     * Gets the aggregation operations (stages) for the query as a list of strings.
+     *
+     * @return the aggregation operations as an ordered list of strings in extended JSON format.
+     */
+    public List<String> getAggregateOperationsAsStrings() {
+        return aggregateOperations.stream()
+                .map(
+                        doc ->
+                                doc.toBsonDocument()
+                                        .toJson(JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build()))
+                .collect(Collectors.toList());
+    }
 }

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class DocumentDbQueryContextTest {
+public class DocumentDbMqlQueryContextTest {
 
     @Test
     @DisplayName("Tests that aggregate operations are correctly converted from BSON document to string in getter.")

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
@@ -36,13 +36,21 @@ public class DocumentDbMqlQueryContextTest {
                         + "\"path\": \"$array\", "
                         + "\"includeArrayIndex\": \"array_index_lvl_0\", "
                         + "\"preserveNullAndEmptyArrays\": true}}");
+        // Stage with 3-valued logic (many null checks)
+        stages.add(
+                "{\"$project\": {"
+                        + "\"booleanField\""
+                        + ": {\"$cond\": [{\"$and\": [{\"$gt\": [\"$array.field\", null]}, "
+                        + "{\"$gt\": [\"$array.field2\", null]}]}, "
+                        + "{\"$eq\": [\"$array.field\", \"$array.field2\"]}, null]}}}");
         // Stage with different Bson types
         stages.add(
                 "{\"$project\": {"
+                        + "\"literalNull\": {\"$literal\": null}, "
                         + "\"literalTimestamp\": {\"$date\": {\"$numberLong\": \"1505938660000\"}}, "
                         + "\"literalInt\": {\"$literal\": {\"$numberInt\": \"-2147483648\"}}, "
                         + "\"literalDecimal\": {\"$literal\": {\"$numberDouble\": \"123.45\"}}, "
-                        + "\"literalVarchar\": {\"$literal\": \"Hello\"}, "
+                        + "\"literalVarchar\": {\"$literal\": \"Hello! 你好!\"}, "
                         + "\"literalBinary\": {\"$binary\": {\"base64\": \"RfCr\", \"subType\": \"00\"}}}}");
         // Stage with a lot of nesting and aggregate operators
         stages.add(

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbMqlQueryContextTest.java
@@ -39,8 +39,8 @@ public class DocumentDbMqlQueryContextTest {
         // Stage with 3-valued logic (many null checks)
         stages.add(
                 "{\"$project\": {"
-                        + "\"booleanField\""
-                        + ": {\"$cond\": [{\"$and\": [{\"$gt\": [\"$array.field\", null]}, "
+                        + "\"booleanField\": "
+                        + "{\"$cond\": [{\"$and\": [{\"$gt\": [\"$array.field\", null]}, "
                         + "{\"$gt\": [\"$array.field2\", null]}]}, "
                         + "{\"$eq\": [\"$array.field\", \"$array.field2\"]}, null]}}}");
         // Stage with different Bson types

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryContextTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryContextTest.java
@@ -46,17 +46,15 @@ public class DocumentDbQueryContextTest {
                         + "\"literalBinary\": {\"$binary\": {\"base64\": \"RfCr\", \"subType\": \"00\"}}}}");
         // Stage with a lot of nesting and aggregate operators
         stages.add(
-            "{\"$project\": {\"EXPR$0\": {\"$substrCP\": [\"$array.field\", "
-                    + "{\"$subtract\": [\"$array.field2\", {\"$numberInt\": \"1\"}]}, "
-                    + "{\"$subtract\": [\"$array.field1\", \"$array.field2\"]}]}, "
-                    + "\"_id\": {\"$numberInt\": \"0\"}}}");
+                "{\"$project\": {\"EXPR$0\": {\"$substrCP\": [\"$array.field\", "
+                        + "{\"$subtract\": [\"$array.field2\", {\"$numberInt\": \"1\"}]}, "
+                        + "{\"$subtract\": [\"$array.field1\", \"$array.field2\"]}]}, "
+                        + "\"_id\": {\"$numberInt\": \"0\"}}}");
 
         final DocumentDbMqlQueryContext context =
                 DocumentDbMqlQueryContext.builder()
                         .aggregateOperations(
-                                stages.stream()
-                                        .map(BsonDocument::parse)
-                                        .collect(Collectors.toList()))
+                                stages.stream().map(BsonDocument::parse).collect(Collectors.toList()))
                         .build();
         Assertions.assertEquals(stages.size(), context.getAggregateOperationsAsStrings().size());
         for (int i = 0; i < stages.size(); i++) {

--- a/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryContextTest.java
+++ b/calcite-adapter/src/test/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryContextTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright <2021> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.amazon.documentdb.jdbc.query;
+
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DocumentDbQueryContextTest {
+
+    @Test
+    @DisplayName("Tests that aggregate operations are correctly converted from BSON document to string in getter.")
+    void testGetAggregateOperationsAsStrings() {
+        final List<String> stages = new ArrayList<>();
+        // Generic stage
+        stages.add(
+                "{\"$unwind\": {"
+                        + "\"path\": \"$array\", "
+                        + "\"includeArrayIndex\": \"array_index_lvl_0\", "
+                        + "\"preserveNullAndEmptyArrays\": true}}");
+        // Stage with different Bson types
+        stages.add(
+                "{\"$project\": {"
+                        + "\"literalTimestamp\": {\"$date\": {\"$numberLong\": \"1505938660000\"}}, "
+                        + "\"literalInt\": {\"$literal\": {\"$numberInt\": \"-2147483648\"}}, "
+                        + "\"literalDecimal\": {\"$literal\": {\"$numberDouble\": \"123.45\"}}, "
+                        + "\"literalVarchar\": {\"$literal\": \"Hello\"}, "
+                        + "\"literalBinary\": {\"$binary\": {\"base64\": \"RfCr\", \"subType\": \"00\"}}}}");
+        // Stage with a lot of nesting and aggregate operators
+        stages.add(
+            "{\"$project\": {\"EXPR$0\": {\"$substrCP\": [\"$array.field\", "
+                    + "{\"$subtract\": [\"$array.field2\", {\"$numberInt\": \"1\"}]}, "
+                    + "{\"$subtract\": [\"$array.field1\", \"$array.field2\"]}]}, "
+                    + "\"_id\": {\"$numberInt\": \"0\"}}}");
+
+        final DocumentDbMqlQueryContext context =
+                DocumentDbMqlQueryContext.builder()
+                        .aggregateOperations(
+                                stages.stream()
+                                        .map(BsonDocument::parse)
+                                        .collect(Collectors.toList()))
+                        .build();
+        Assertions.assertEquals(stages.size(), context.getAggregateOperationsAsStrings().size());
+        for (int i = 0; i < stages.size(); i++) {
+            Assertions.assertEquals(stages.get(i), context.getAggregateOperationsAsStrings().get(i));
+        }
+    }
+}


### PR DESCRIPTION
### Summary

- Added public method in DocumentDbMqlQueryContext to return aggregate operations as strings instead of Bson Documents

### Description

- Added unit test 
- Added public method in DocumentDbMqlQueryContext 

### Related Issue

https://bitquill.atlassian.net/browse/AD-627

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
