### PR TITLE
fixing javadoc task errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'org.kordamp.gradle.markdown' version '2.2.0'
     id "de.undercouch.download" version "5.0.1"
     id "com.github.dkorotych.gradle-maven-exec" version "2.2.1"
+    id "io.freefair.aggregate-javadoc" version "5.3.3.3"
 }
 
 group 'software.amazon.documentdb.jdbc'

--- a/calcite-adapter/build.gradle
+++ b/calcite-adapter/build.gradle
@@ -41,7 +41,6 @@ task delombok(type: DelombokTask, dependsOn: compileJava) {
 javadoc {
     dependsOn delombok
     source = delombok.outputDir
-    failOnError = false
 }
 
 jar {

--- a/calcite-adapter/build.gradle
+++ b/calcite-adapter/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'checkstyle'
     id 'jacoco'
     id 'com.github.hierynomus.license' // version '0.15.0'
+    id 'io.franzbecker.gradle-lombok' version '5.0.0'
 }
 
 group 'software.amazon.documentdb.jdbc'
@@ -25,6 +26,22 @@ if (hasProperty('buildScan')) {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
     }
+}
+
+import io.franzbecker.gradle.lombok.task.DelombokTask
+task delombok(type: DelombokTask, dependsOn: compileJava) {
+    ext.outputDir = file("$buildDir/delombok")
+    outputs.dir(outputDir)
+    sourceSets.main.java.srcDirs.each {
+        inputs.dir(it)
+        args(it, "-d", outputDir)
+    }
+}
+
+javadoc {
+    dependsOn delombok
+    source = delombok.outputDir
+    failOnError = false
 }
 
 jar {

--- a/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbSchemaTable.java
+++ b/calcite-adapter/src/main/java/software/amazon/documentdb/jdbc/metadata/DocumentDbSchemaTable.java
@@ -56,7 +56,7 @@ public class DocumentDbSchemaTable {
     /**
      * The unique ID for the table schema.
      *
-     * @return a {@link String} representing the combination of {@link #getSqlName} and
+     * @return a {@link String} representing the combination of {@link #getSqlName()} and
      * {@link #getUuid}.
      */
     @BsonId

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -1158,7 +1158,7 @@ public class DocumentDbConnectionProperties extends Properties {
      * '~' to be replaced by the user's home directory.
      *
      * @param filePath the given file path to process.
-     * @param searchFolders
+     * @param searchFolders list of folders
      * @return a {@link Path} for the absolution path for the given file path.
      */
     public static Path getPath(final String filePath, final String... searchFolders) {

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -1158,6 +1158,7 @@ public class DocumentDbConnectionProperties extends Properties {
      * '~' to be replaced by the user's home directory.
      *
      * @param filePath the given file path to process.
+     * @param searchFolders
      * @return a {@link Path} for the absolution path for the given file path.
      */
     public static Path getPath(final String filePath, final String... searchFolders) {

--- a/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/DocumentDbConnectionProperties.java
@@ -874,6 +874,7 @@ public class DocumentDbConnectionProperties extends Properties {
      *
      * @param info the given properties.
      * @param documentDbUrl the connection string.
+     * @param connectionStringPrefix the connection string prefix.
      * @return a {@link DocumentDbConnectionProperties} with the properties set.
      * @throws SQLException if connection string is invalid.
      */

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/Connection.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/Connection.java
@@ -187,7 +187,7 @@ public abstract class Connection implements java.sql.Connection {
 
     /**
      * Closes the connection and releases resources.
-     * @throws SQLException
+     * @throws SQLException throws SQLException
      */
     protected abstract void doClose() throws SQLException;
 

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/Connection.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/Connection.java
@@ -187,6 +187,7 @@ public abstract class Connection implements java.sql.Connection {
 
     /**
      * Closes the connection and releases resources.
+     * @throws SQLException
      */
     protected abstract void doClose() throws SQLException;
 

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/PreparedStatement.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/PreparedStatement.java
@@ -52,7 +52,6 @@ public abstract class PreparedStatement extends Statement implements java.sql.Pr
      *
      * @param connection The parent connection.
      * @param sql        The sql query.
-     * @throws SQLException if error occurs when get type map of connection.
      */
     protected PreparedStatement(final Connection connection, final String sql) {
         super(connection);

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/ResultSet.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/ResultSet.java
@@ -70,21 +70,21 @@ public abstract class ResultSet implements java.sql.ResultSet {
     /**
      * Set the driver fetch size by the number of rows.
      * @param rows The number of rows for the driver to fetch.
-     * @throws SQLException
+     * @throws SQLException throws SQLException
      */
     protected abstract void setDriverFetchSize(int rows) throws SQLException;
 
     /**
      * Gets the current row (zero-based) index.
      * @return A value representing the current row (zero-based) index.
-     * @throws SQLException
+     * @throws SQLException throws SQLException
      */
     protected abstract int getRowIndex() throws SQLException;
 
     /**
      * Gets the number of rows in the result set.
      * @return A value representing the number of rows in the result set.
-     * @throws SQLException
+     * @throws SQLException throws SQLException
      */
     protected abstract int getRowCount() throws SQLException;
 

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/ResultSet.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/ResultSet.java
@@ -70,18 +70,21 @@ public abstract class ResultSet implements java.sql.ResultSet {
     /**
      * Set the driver fetch size by the number of rows.
      * @param rows The number of rows for the driver to fetch.
+     * @throws SQLException
      */
     protected abstract void setDriverFetchSize(int rows) throws SQLException;
 
     /**
      * Gets the current row (zero-based) index.
      * @return A value representing the current row (zero-based) index.
+     * @throws SQLException
      */
     protected abstract int getRowIndex() throws SQLException;
 
     /**
      * Gets the number of rows in the result set.
      * @return A value representing the number of rows in the result set.
+     * @throws SQLException
      */
     protected abstract int getRowCount() throws SQLException;
 

--- a/common/src/main/java/software/amazon/documentdb/jdbc/common/Statement.java
+++ b/common/src/main/java/software/amazon/documentdb/jdbc/common/Statement.java
@@ -46,7 +46,6 @@ public abstract class Statement implements java.sql.Statement {
      * Constructor for seeding the statement with the parent connection.
      *
      * @param connection The parent connection.
-     * @throws SQLException if error occurs when get type map of connection.
      */
     protected Statement(final java.sql.Connection connection) {
         this.connection = connection;

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbAbstractResultSet.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbAbstractResultSet.java
@@ -185,6 +185,7 @@ public abstract class DocumentDbAbstractResultSet extends
      * @param columnIndex the (one-based) column index in the current row.
      *
      * @return the cell value.
+     * @throws SQLException throws a SQLException
      */
     protected abstract Object getValue(final int columnIndex) throws SQLException;
 

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbQueryExecutor.java
@@ -160,6 +160,7 @@ public class DocumentDbQueryExecutor {
      * Function to execute query.
      * @param sql Query to execute.
      * @return java.sql.ResultSet object returned from query execution.
+     * @throws SQLException throws a SQLException
      */
     @VisibleForTesting
     protected java.sql.ResultSet runQuery(final String sql) throws SQLException {


### PR DESCRIPTION
### Summary

fixing Javadoc task errors

### Description

Javadoc task was throwing an error when a generated method by Lombok was linked in the Javadoc. To fix that, we need to delombok the class before the Javadoc task run.
Changes are adding a plugin and a task before the Javadoc task.

- [X] fix Javadoc generation

- [X] fix Javadoc warnings and errors

- [X] Aggregate multiple Javadoc in only one

- [X] cross review our documentation

### Related Issue

https://bitquill.atlassian.net/browse/AD-654

### Additional Reviewers
@affonsoBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
