### PR TITLE
[AD-550] no longer treat schema and catalog as patterns in getPrimaryKeys and getImportedKeys

### DIFF
--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
@@ -496,9 +496,9 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
         // 5. KEY_SEQ short => sequence number within primary key( a value of 1 represents the first column of the primary key, a value of 2 would represent the second column within the primary key).
         // 6. PK_NAME String => primary key name (may be null)
         final List<List<Object>> metaData = new ArrayList<>();
-        if (schema == null) {
+        if (schema == null || properties.getDatabase().equals(schema)) {
             for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-                if (table == null) {
+                if (table == null || tableName.equals(table)) {
                     final DocumentDbSchemaTable metadataTable = databaseMetadata
                             .getTableSchemaMap().get(tableName);
                     if (metadataTable == null) {
@@ -546,7 +546,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final String table) throws SQLException {
         final List<List<Object>> metaData = new ArrayList<>();
         if (isNullOrWhitespace(catalog)) {
-            if (schema == null) {
+            if (schema == null || properties.getDatabase().equals(schema)) {
                 addImportedKeysForSchema(table, metaData);
             }
         }

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
@@ -498,7 +498,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
         final List<List<Object>> metaData = new ArrayList<>();
         final String regexSchemaPattern = convertPatternToRegex(schema);
         final String regexTableSchemaPattern = convertPatternToRegex(table);
-        if (isNullOrWhitespace(schema)|| properties.getDatabase().matches(regexSchemaPattern)) {
+        if (isNullOrWhitespace(schema) || properties.getDatabase().matches(regexSchemaPattern)) {
             for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
                 if (isNullOrWhitespace(table) ||
                         tableName.matches(regexTableSchemaPattern)) {
@@ -549,7 +549,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final String table) throws SQLException {
         final List<List<Object>> metaData = new ArrayList<>();
         if (isNullOrWhitespace(catalog)) {
-            if (isNullOrWhitespace(schema)|| properties.getDatabase().matches(convertPatternToRegex(schema))) {
+            if (isNullOrWhitespace(schema) || properties.getDatabase().matches(convertPatternToRegex(schema))) {
                 addImportedKeysForSchema(table, metaData);
             }
         }
@@ -564,7 +564,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final List<List<Object>> metaData) throws SQLException {
         final String regexTablePattern = convertPatternToRegex(table);
         for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-            if (isNullOrWhitespace(table)|| tableName.matches(regexTablePattern)) {
+            if (isNullOrWhitespace(table) || tableName.matches(regexTablePattern)) {
                 final DocumentDbSchemaTable schemaTable = databaseMetadata
                         .getTableSchemaMap().get(tableName);
                 if (schemaTable == null) {

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
@@ -498,9 +498,9 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
         final List<List<Object>> metaData = new ArrayList<>();
         final String regexSchemaPattern = convertPatternToRegex(schema);
         final String regexTableSchemaPattern = convertPatternToRegex(table);
-        if (isNullOrWhitespace(schema) || properties.getDatabase().matches(regexSchemaPattern)) {
+        if (schema == null || properties.getDatabase().matches(regexSchemaPattern)) {
             for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-                if (isNullOrWhitespace(table) ||
+                if (table == null ||
                         tableName.matches(regexTableSchemaPattern)) {
                     final DocumentDbSchemaTable metadataTable = databaseMetadata
                             .getTableSchemaMap().get(tableName);
@@ -549,7 +549,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final String table) throws SQLException {
         final List<List<Object>> metaData = new ArrayList<>();
         if (isNullOrWhitespace(catalog)) {
-            if (isNullOrWhitespace(schema) || properties.getDatabase().matches(convertPatternToRegex(schema))) {
+            if (schema == null || properties.getDatabase().matches(convertPatternToRegex(schema))) {
                 addImportedKeysForSchema(table, metaData);
             }
         }
@@ -564,7 +564,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final List<List<Object>> metaData) throws SQLException {
         final String regexTablePattern = convertPatternToRegex(table);
         for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-            if (isNullOrWhitespace(table) || tableName.matches(regexTablePattern)) {
+            if (table == null || tableName.matches(regexTablePattern)) {
                 final DocumentDbSchemaTable schemaTable = databaseMetadata
                         .getTableSchemaMap().get(tableName);
                 if (schemaTable == null) {

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
@@ -498,9 +498,9 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
         final List<List<Object>> metaData = new ArrayList<>();
         final String regexSchemaPattern = convertPatternToRegex(schema);
         final String regexTableSchemaPattern = convertPatternToRegex(table);
-        if (schema == null || properties.getDatabase().matches(regexSchemaPattern)) {
+        if (isNullOrWhitespace(schema)|| properties.getDatabase().matches(regexSchemaPattern)) {
             for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-                if (table == null ||
+                if (isNullOrWhitespace(table) ||
                         tableName.matches(regexTableSchemaPattern)) {
                     final DocumentDbSchemaTable metadataTable = databaseMetadata
                             .getTableSchemaMap().get(tableName);
@@ -549,7 +549,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final String table) throws SQLException {
         final List<List<Object>> metaData = new ArrayList<>();
         if (isNullOrWhitespace(catalog)) {
-            if (schema == null || properties.getDatabase().matches(convertPatternToRegex(schema))) {
+            if (isNullOrWhitespace(schema)|| properties.getDatabase().matches(convertPatternToRegex(schema))) {
                 addImportedKeysForSchema(table, metaData);
             }
         }
@@ -564,7 +564,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final List<List<Object>> metaData) throws SQLException {
         final String regexTablePattern = convertPatternToRegex(table);
         for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-            if (table == null || tableName.matches(regexTablePattern)) {
+            if (isNullOrWhitespace(table)|| tableName.matches(regexTablePattern)) {
                 final DocumentDbSchemaTable schemaTable = databaseMetadata
                         .getTableSchemaMap().get(tableName);
                 if (schemaTable == null) {

--- a/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaData.java
@@ -496,12 +496,9 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
         // 5. KEY_SEQ short => sequence number within primary key( a value of 1 represents the first column of the primary key, a value of 2 would represent the second column within the primary key).
         // 6. PK_NAME String => primary key name (may be null)
         final List<List<Object>> metaData = new ArrayList<>();
-        final String regexSchemaPattern = convertPatternToRegex(schema);
-        final String regexTableSchemaPattern = convertPatternToRegex(table);
-        if (schema == null || properties.getDatabase().matches(regexSchemaPattern)) {
+        if (schema == null) {
             for (String tableName : databaseMetadata.getTableSchemaMap().keySet()) {
-                if (table == null ||
-                        tableName.matches(regexTableSchemaPattern)) {
+                if (table == null) {
                     final DocumentDbSchemaTable metadataTable = databaseMetadata
                             .getTableSchemaMap().get(tableName);
                     if (metadataTable == null) {
@@ -549,7 +546,7 @@ public class DocumentDbDatabaseMetaData extends DatabaseMetaData implements java
             final String table) throws SQLException {
         final List<List<Object>> metaData = new ArrayList<>();
         if (isNullOrWhitespace(catalog)) {
-            if (schema == null || properties.getDatabase().matches(convertPatternToRegex(schema))) {
+            if (schema == null) {
                 addImportedKeysForSchema(table, metaData);
             }
         }

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
@@ -500,6 +500,27 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
     }
 
     @Test
+    @DisplayName("Tests primary keys of array virtual tables with white space parameters.")
+    void testGetPrimaryKeysArrayWithWhiteSpace() throws SQLException {
+        final ResultSet arrayPrimaryKeys = metadata.getPrimaryKeys("", "", COLLECTION_ARRAY + "_array");
+        Assertions.assertTrue(arrayPrimaryKeys.next());
+        Assertions.assertNull(arrayPrimaryKeys.getString(1));
+        Assertions.assertEquals(DATABASE, arrayPrimaryKeys.getString(2));
+        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayPrimaryKeys.getString(3));
+        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayPrimaryKeys.getString(4));
+        Assertions.assertEquals(1, arrayPrimaryKeys.getShort(5));
+        Assertions.assertNull(arrayPrimaryKeys.getString(6));
+        Assertions.assertTrue(arrayPrimaryKeys.next());
+        Assertions.assertNull(arrayPrimaryKeys.getString(1));
+        Assertions.assertEquals(DATABASE, arrayPrimaryKeys.getString(2));
+        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayPrimaryKeys.getString(3));
+        Assertions.assertEquals("array_index_lvl_0", arrayPrimaryKeys.getString(4));
+        Assertions.assertEquals(2, arrayPrimaryKeys.getShort(5)); // Indicates second column of PK
+        Assertions.assertNull(arrayPrimaryKeys.getString(6));
+        Assertions.assertFalse(arrayPrimaryKeys.next());
+    }
+
+    @Test
     @DisplayName("Tests foreign keys of sub-document virtual tables.")
     void testGetImportedKeysDocument() throws SQLException {
         final ResultSet subdocImportedKeys = metadata.getImportedKeys(null, null, COLLECTION_SUB + "_doc");

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
@@ -470,15 +470,6 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
     }
 
     @Test
-    @DisplayName("Tests primary/foreign key queries with wildcard characters (% and _)")
-    void testPrimaryKeyWildcards() throws SQLException {
-        final ResultSet primaryWildcardKeys = metadata.getPrimaryKeys(null, null, "_ollect%");
-        Assertions.assertTrue(primaryWildcardKeys.next());
-        final ResultSet foreignWildcardKeys = metadata.getImportedKeys(null, null, "_ollect%");
-        Assertions.assertTrue(foreignWildcardKeys.next());
-    }
-
-    @Test
     @DisplayName("Tests primary keys of array virtual tables.")
     void testGetPrimaryKeysArray() throws SQLException {
         final ResultSet arrayPrimaryKeys = metadata.getPrimaryKeys(null, null, COLLECTION_ARRAY + "_array");

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
@@ -491,7 +491,7 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
     }
 
     @Test
-    @DisplayName("Tests primary keys of array virtual tables with white space parameters. An empty ResultSet should be returned.")
+    @DisplayName("Tests primary keys of array virtual tables with empty string parameters. An empty ResultSet should be returned.")
     void testGetPrimaryKeysArrayWithWhiteSpace() throws SQLException {
         final ResultSet arrayPrimaryKeys = metadata.getPrimaryKeys("", "", COLLECTION_ARRAY + "_array");
         Assertions.assertFalse(arrayPrimaryKeys.next());

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
@@ -500,23 +500,9 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
     }
 
     @Test
-    @DisplayName("Tests primary keys of array virtual tables with white space parameters.")
+    @DisplayName("Tests primary keys of array virtual tables with white space parameters. An empty ResultSet should be returned.")
     void testGetPrimaryKeysArrayWithWhiteSpace() throws SQLException {
         final ResultSet arrayPrimaryKeys = metadata.getPrimaryKeys("", "", COLLECTION_ARRAY + "_array");
-        Assertions.assertTrue(arrayPrimaryKeys.next());
-        Assertions.assertNull(arrayPrimaryKeys.getString(1));
-        Assertions.assertEquals(DATABASE, arrayPrimaryKeys.getString(2));
-        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayPrimaryKeys.getString(3));
-        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayPrimaryKeys.getString(4));
-        Assertions.assertEquals(1, arrayPrimaryKeys.getShort(5));
-        Assertions.assertNull(arrayPrimaryKeys.getString(6));
-        Assertions.assertTrue(arrayPrimaryKeys.next());
-        Assertions.assertNull(arrayPrimaryKeys.getString(1));
-        Assertions.assertEquals(DATABASE, arrayPrimaryKeys.getString(2));
-        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayPrimaryKeys.getString(3));
-        Assertions.assertEquals("array_index_lvl_0", arrayPrimaryKeys.getString(4));
-        Assertions.assertEquals(2, arrayPrimaryKeys.getShort(5)); // Indicates second column of PK
-        Assertions.assertNull(arrayPrimaryKeys.getString(6));
         Assertions.assertFalse(arrayPrimaryKeys.next());
     }
 
@@ -555,19 +541,9 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
     }
 
     @Test
-    @DisplayName("Tests foreign keys of array virtual tables with whitespace parameters.")
+    @DisplayName("Tests foreign keys of array virtual tables with whitespace parameters. An empty ResultSet should be returned")
     void testGetImportedKeysArrayWithWhiteSpaces() throws SQLException {
         final ResultSet arrayImportedKeys = metadata.getImportedKeys("", "", COLLECTION_ARRAY + "_array");
-        Assertions.assertTrue(arrayImportedKeys.next());
-        Assertions.assertNull(arrayImportedKeys.getString(1));
-        Assertions.assertEquals(DATABASE, arrayImportedKeys.getString(2));
-        Assertions.assertEquals(COLLECTION_ARRAY, arrayImportedKeys.getString(3));
-        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayImportedKeys.getString(4));
-        Assertions.assertNull(arrayImportedKeys.getString(5));
-        Assertions.assertEquals(DATABASE, arrayImportedKeys.getString(6));
-        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayImportedKeys.getString(7));
-        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayImportedKeys.getString(8));
-        Assertions.assertEquals(1, arrayImportedKeys.getShort(9));
         Assertions.assertFalse(arrayImportedKeys.next());
     }
 }

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbDatabaseMetaDataTest.java
@@ -532,4 +532,21 @@ public class DocumentDbDatabaseMetaDataTest extends DocumentDbFlapDoodleTest {
         Assertions.assertEquals(1, arrayImportedKeys.getShort(9));
         Assertions.assertFalse(arrayImportedKeys.next());
     }
+
+    @Test
+    @DisplayName("Tests foreign keys of array virtual tables with whitespace parameters.")
+    void testGetImportedKeysArrayWithWhiteSpaces() throws SQLException {
+        final ResultSet arrayImportedKeys = metadata.getImportedKeys("", "", COLLECTION_ARRAY + "_array");
+        Assertions.assertTrue(arrayImportedKeys.next());
+        Assertions.assertNull(arrayImportedKeys.getString(1));
+        Assertions.assertEquals(DATABASE, arrayImportedKeys.getString(2));
+        Assertions.assertEquals(COLLECTION_ARRAY, arrayImportedKeys.getString(3));
+        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayImportedKeys.getString(4));
+        Assertions.assertNull(arrayImportedKeys.getString(5));
+        Assertions.assertEquals(DATABASE, arrayImportedKeys.getString(6));
+        Assertions.assertEquals(COLLECTION_ARRAY + "_array", arrayImportedKeys.getString(7));
+        Assertions.assertEquals(COLLECTION_ARRAY + "__id", arrayImportedKeys.getString(8));
+        Assertions.assertEquals(1, arrayImportedKeys.getShort(9));
+        Assertions.assertFalse(arrayImportedKeys.next());
+    }
 }


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
make JDBC no longer treat schema and catalog as patterns in getPrimaryKeys and getImportedKeys

### Description

<!--- Details of what you changed -->
- remove testPrimaryKeyWildcards test
- make JDBC not treat schema and catalog as patterns in getPrimaryKeys and getImportedKeys
- add unit test to ensure that empty resultsets are returned when white space is passed as schema name to function getPrimaryKeys or getImportedKeys
### Related Issue

<!--- Link to issue where this is tracked -->
https://bitquill.atlassian.net/browse/AD-550

### Additional Reviewers
@affonsoBQ
@alinaliBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
@mitchell-elholm
@RoyZhang2022
