### PR TITLE
[AD-764] Set Calcite's default charset to UTF-8 to allow Unicode queries

### DIFF
--- a/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingService.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/query/DocumentDbQueryMappingService.java
@@ -77,6 +77,8 @@ import java.util.Map;
 
 public class DocumentDbQueryMappingService {
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentDbQueryMappingService.class);
+    private static final String CALCITE_DEFAULT_CHARSET = "calcite.default.charset";
+    private static final String CHARSET_UTF_8 = "utf8";
     private final DocumentDbPrepareContext prepareContext;
     private final CalcitePrepare prepare;
     private final BsonDocument maxRowsBSON;
@@ -96,6 +98,10 @@ public class DocumentDbQueryMappingService {
         // Leave unquoted identifiers in their original case. Identifiers are still case-sensitive
         // but do not need to be quoted
         connectionProperties.putIfAbsent("UNQUOTEDCASING", "UNCHANGED");
+        // Allow Unicode (utf-8) queries to be handled.
+        if (System.getProperty(CALCITE_DEFAULT_CHARSET) == null) {
+            System.setProperty(CALCITE_DEFAULT_CHARSET, CHARSET_UTF_8);
+        }
         this.prepareContext =
                 new DocumentDbPrepareContext(
                         getRootSchemaFromDatabaseMetadata(connectionProperties, databaseMetadata),


### PR DESCRIPTION
### Summary

[AD-764] Set Calcite's default charset to UTF-8 to allow Unicode queries

### Description

Set the system property so that Calcite's default charset is utf-8 (if not already set).

### Related Issue

https://bitquill.atlassian.net/browse/AD-764

### Additional Reviewers
@affonsoBQ
@alinaliBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
