### PR TITLE
[AD-829] Disable remote integration testing, by default.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,16 +105,14 @@ artifacts {
 
 test {
     useJUnitPlatform {
-        if (project.hasProperty('runRemoteIntegrationTests') && project.property('runRemoteIntegrationTests') == 'false') {
-            environment "connectionString", project.CONNECTION_STRING_LOCAL
-            // Ensure to match the enumeration name exactly from DocumentDbTestEnvironmentType.
-            environment "CONFIGURED_ENVIRONMENTS", "MONGODB40_FLAPDOODLE"
-            excludeTags 'remote-integration'
-        } else {
-            environment "connectionString", project.CONNECTION_STRING_REMOTE
+        if (project.hasProperty('runRemoteIntegrationTests') && project.property('runRemoteIntegrationTests') == 'true') {
             // Ensure to match the enumeration name exactly from DocumentDbTestEnvironmentType.
             environment "CONFIGURED_ENVIRONMENTS", "MONGODB40_FLAPDOODLE,DOCUMENTDB40_SSH_TUNNEL"
             excludeTags 'local-integration'
+        } else {
+            // Ensure to match the enumeration name exactly from DocumentDbTestEnvironmentType.
+            environment "CONFIGURED_ENVIRONMENTS", "MONGODB40_FLAPDOODLE"
+            excludeTags 'remote-integration'
         }
     }
 }
@@ -401,16 +399,3 @@ signing {
     sign publishing.publications.mavenJava
 }
 
-test {
-    useJUnitPlatform {
-        if (project.hasProperty('runRemoteIntegrationTests') && project.property('runRemoteIntegrationTests') == 'false') {
-            // Ensure to match the enumeration name exactly from DocumentDbTestEnvironmentType.
-            environment "CONFIGURED_ENVIRONMENTS", "MONGODB40_FLAPDOODLE"
-            excludeTags 'remote-integration'
-        } else {
-            // Ensure to match the enumeration name exactly from DocumentDbTestEnvironmentType.
-            environment "CONFIGURED_ENVIRONMENTS", "MONGODB40_FLAPDOODLE,DOCUMENTDB40_SSH_TUNNEL"
-            excludeTags 'local-integration'
-        }
-    }
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,9 @@
 org.gradle.warning.mode=all
-CONNECTION_STRING_LOCAL=jdbc:documentdb://username:password@localhost/database
-CONNECTION_STRING_REMOTE=jdbc:documentdb://username:password@remotehost/database
 MAJOR_VERSION=1
 MINOR_VERSION=2
 PATCH_VERSION=4
 APPLICATION_NAME=Amazon DocumentDB JDBC Driver
 # Comment out if not creating a beta version
 #BETA_VERSION=1
-# Uncomment out next line to disable remote integration tests
-#runRemoteIntegrationTests=false
+# Uncomment out next line to enable remote integration tests
+#runRemoteIntegrationTests=true

--- a/src/test/java/software/amazon/documentdb/jdbc/DocumentDbIntegrationTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/DocumentDbIntegrationTest.java
@@ -33,9 +33,9 @@ public class DocumentDbIntegrationTest {
     @Tag("local-integration")
     public void runLocalTest() {
         Assertions.assertEquals(true, true);
-        final String connectionString = System.getenv("connectionString");
-        Assertions.assertNotNull(connectionString);
-        Assertions.assertTrue(Pattern.matches(".*localhost.*", connectionString));
+        final String configuredEnvironments = System.getenv("CONFIGURED_ENVIRONMENTS");
+        Assertions.assertNotNull(configuredEnvironments);
+        Assertions.assertFalse(Pattern.matches(".*DOCUMENTDB40_SSH_TUNNEL.*", configuredEnvironments));
     }
 
     /**
@@ -45,8 +45,8 @@ public class DocumentDbIntegrationTest {
     @Tag("remote-integration")
     public void runRemoteTest() {
         Assertions.assertEquals(true, true);
-        final String connectionString = System.getenv("connectionString");
-        Assertions.assertNotNull(connectionString);
-        Assertions.assertTrue(Pattern.matches(".*remotehost.*", connectionString));
+        final String configuredEnvironments = System.getenv("CONFIGURED_ENVIRONMENTS");
+        Assertions.assertNotNull(configuredEnvironments);
+        Assertions.assertTrue(Pattern.matches(".*DOCUMENTDB40_SSH_TUNNEL.*", configuredEnvironments));
     }
 }


### PR DESCRIPTION
### Summary

[AD-829] Disable remote integration testing, by default.

### Description

Change the default for remote integration testing from TRUE to FALSE. This will make is easier for open source contributors to test without having to have the server secrets.

### Related Issue

https://bitquill.atlassian.net/browse/AD-829

### Additional Reviewers
@affonsoBQ
@alinaliBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
