### PR TITLE
[AD-997] Add tests to ensure SQL or mongo injection is not possible.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,8 +323,8 @@ repositories {
 
 dependencies {
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.5.0'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava', version: '2.14.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.1'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava', version: '2.14.1'
     implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
     implementation group: 'org.slf4j', name: 'slf4j-log4j12', version: '2.0.4'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'

--- a/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbRules.java
+++ b/src/main/java/software/amazon/documentdb/jdbc/calcite/adapter/DocumentDbRules.java
@@ -96,7 +96,7 @@ public final class DocumentDbRules {
     static final Map<String, String> ESCAPE_MAP;
 
     static {
-        Map<String, String> escapeMap = new HashMap<>();
+        final Map<String, String> escapeMap = new HashMap<>();
         escapeMap.put("[']", "\\'");
         ESCAPE_MAP = Collections.unmodifiableMap(escapeMap);
     }
@@ -194,6 +194,13 @@ public final class DocumentDbRules {
         return quote(s, '\'', ESCAPE_MAP);
     }
 
+    /**
+     * Quotes a string with the given quote character, handling any escape substitutions provided.
+     * @param s the value to quote.
+     * @param quoteChar the character to quote the value with.
+     * @param escapeMap the map of regular expressions to escaped replacement values.
+     * @return an escaped and quoted value.
+     */
     public static String quote(final String s, final char quoteChar, final Map<String, String> escapeMap) {
         String value = s;
         for (Map.Entry<String, String> entry : escapeMap.entrySet()) {

--- a/src/test/java/software/amazon/documentdb/jdbc/query/limitations/DocumentDbSqlInjectionTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/query/limitations/DocumentDbSqlInjectionTest.java
@@ -51,8 +51,9 @@ class DocumentDbSqlInjectionTest extends DocumentDbQueryMappingServiceTest {
                                 + "{ \"field\" : 1, \"field1\": \"value\" }, "
                                 + "{ \"field\" : 2, \"field2\" : \"value\" , \"field3\" : { \"field4\": 3} } ]}");
         final BsonDocument otherDocument =
-                BsonDocument.parse(
-                        "{ \"_id\" : \"key1\", \"otherArray\" : [ { \"field\" : 1, \"field3\": \"value\" }, { \"field\" : 2, \"field3\" : \"value\" } ]}");
+                BsonDocument.parse("{\"_id\": \"key1\", \"otherArray\": [" +
+                        "{\"field\": 1, \"field3\": \"value\"}, " +
+                        "{\"field\": 2, \"field3\": \"value\"}]}");
         insertBsonDocuments(COLLECTION_NAME, new BsonDocument[] {document});
         insertBsonDocuments(OTHER_COLLECTION_NAME, new BsonDocument[] {otherDocument});
         queryMapper = getQueryMappingService();
@@ -77,7 +78,9 @@ class DocumentDbSqlInjectionTest extends DocumentDbQueryMappingServiceTest {
         final DocumentDbMqlQueryContext queryContext = queryMapper.get(query);
         Assertions.assertNotNull(queryContext);
         final List<Bson> aggregateOperations = queryContext.getAggregateOperations();
+        // Assert that the attempted injection did not add a '$delete' operation.
         assertKeyNotExists(expectedKey, aggregateOperations);
+        // Assert that the attempted injection is interpreted as a '$literal' value
         assertValueExists(injection, aggregateOperations);
 
         final String query2 = String.format(

--- a/src/test/java/software/amazon/documentdb/jdbc/query/limitations/DocumentDbSqlInjectionTest.java
+++ b/src/test/java/software/amazon/documentdb/jdbc/query/limitations/DocumentDbSqlInjectionTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright <2021> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package software.amazon.documentdb.jdbc.query.limitations;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.conversions.Bson;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.documentdb.jdbc.common.test.DocumentDbFlapDoodleExtension;
+import software.amazon.documentdb.jdbc.query.DocumentDbMqlQueryContext;
+import software.amazon.documentdb.jdbc.query.DocumentDbQueryMappingService;
+import software.amazon.documentdb.jdbc.query.DocumentDbQueryMappingServiceTest;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+@ExtendWith(DocumentDbFlapDoodleExtension.class)
+class DocumentDbSqlInjectionTest extends DocumentDbQueryMappingServiceTest {
+    private static final String COLLECTION_NAME = "testCollectionInjectionTest";
+    private static final String OTHER_COLLECTION_NAME = "otherTestCollectionInjectionTest";
+    private DocumentDbQueryMappingService queryMapper;
+
+    @BeforeAll
+    void beforeAll() throws SQLException {
+        final BsonDocument document =
+                BsonDocument.parse(
+                        "{ \"_id\" : \"key\", \"array\" : [ "
+                                + "{ \"field\" : 1, \"field1\": \"value\" }, "
+                                + "{ \"field\" : 2, \"field2\" : \"value\" , \"field3\" : { \"field4\": 3} } ]}");
+        final BsonDocument otherDocument =
+                BsonDocument.parse(
+                        "{ \"_id\" : \"key1\", \"otherArray\" : [ { \"field\" : 1, \"field3\": \"value\" }, { \"field\" : 2, \"field3\" : \"value\" } ]}");
+        insertBsonDocuments(COLLECTION_NAME, new BsonDocument[] {document});
+        insertBsonDocuments(OTHER_COLLECTION_NAME, new BsonDocument[] {otherDocument});
+        queryMapper = getQueryMappingService();
+    }
+
+    @Test
+    void testMongoInjections() throws SQLException {
+        final String primaryKeyColumnName = COLLECTION_NAME + "__id";
+        final String injection = String.format(
+                "\"}, {$delete: {\"%1$s\", \"1\"}",
+                primaryKeyColumnName);
+        final String query = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = '%6$s'",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final DocumentDbMqlQueryContext queryContext = queryMapper.get(query);
+        Assertions.assertNotNull(queryContext);
+        final List<Bson> aggregateOperations = queryContext.getAggregateOperations();
+        final String expectedKey = "$delete";
+        assertKeyNotExists(expectedKey, aggregateOperations);
+        assertValueExists(injection, aggregateOperations);
+
+        final String query2 = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM (SELECT * FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = '%6$s')",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final DocumentDbMqlQueryContext queryContext2 = queryMapper.get(query2);
+        Assertions.assertNotNull(queryContext2);
+        final List<Bson> aggregateOperations2 = queryContext2.getAggregateOperations();
+        assertKeyNotExists(expectedKey, aggregateOperations2);
+        assertValueExists(injection, aggregateOperations2);
+
+        final String query3 = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = SUBSTRING('%6$s', 1, 2000)",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final DocumentDbMqlQueryContext queryContext3 = queryMapper.get(query3);
+        Assertions.assertNotNull(queryContext3);
+        final List<Bson> aggregateOperations3 = queryContext3.getAggregateOperations();
+        assertKeyNotExists(expectedKey, aggregateOperations3);
+        assertValueExists(injection, aggregateOperations3);
+
+        final String query4 = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = CONCAT('%6$s', '')",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final DocumentDbMqlQueryContext queryContext4 = queryMapper.get(query4);
+        Assertions.assertNotNull(queryContext4);
+        final List<Bson> aggregateOperations4 = queryContext4.getAggregateOperations();
+        assertKeyNotExists(expectedKey, aggregateOperations4);
+        assertValueExists(injection, aggregateOperations4);
+
+        final String query5 = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = REVERSE('%6$s')",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                new StringBuilder(injection).reverse());
+        final DocumentDbMqlQueryContext queryContext5 = queryMapper.get(query5);
+        Assertions.assertNotNull(queryContext5);
+        final List<Bson> aggregateOperations5 = queryContext5.getAggregateOperations();
+        assertKeyNotExists(expectedKey, aggregateOperations5);
+        assertValueExists(injection, aggregateOperations5);
+    }
+
+    @Test
+    void testSqlInjections() {
+        final String primaryKeyColumnName = COLLECTION_NAME + "__id";
+        final String injection = String.format(
+                "'; DELETE FROM \"%1$s\" WHERE \"%2$s\" <> '",
+                COLLECTION_NAME,
+                primaryKeyColumnName);
+        final String query = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = '%6$s'",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final Exception exception = Assertions.assertThrows(SQLException.class, () -> queryMapper.get(query));
+        Assertions.assertTrue(exception.getMessage().contains("Reason: 'parse failed: Encountered \";\" at line 1"));
+
+        final String query2 = String.format(
+                "SELECT \"%1$s\", \"%2$s\", \"%3$s\" FROM (SELECT * FROM \"%4$s\".\"%5$s\"" +
+                        " WHERE \"%1$s\" = '%6$s')",
+                primaryKeyColumnName,
+                "field",
+                "field1",
+                getDatabaseName(),
+                COLLECTION_NAME + "_array",
+                injection);
+        final Exception exception2 = Assertions.assertThrows(SQLException.class, () -> queryMapper.get(query2));
+        Assertions.assertTrue(exception2.getMessage().contains("Reason: 'parse failed: Encountered \";\" at line 1"));
+    }
+
+    private static void assertKeyNotExists(final @NonNull String expectedKey, final List<Bson> aggregateOperations) {
+        for (final Bson op : aggregateOperations) {
+            final BsonDocument doc = op.toBsonDocument();
+            assertKeyNotExists(expectedKey, doc);
+        }
+    }
+
+    private static void assertValueExists(final @NonNull String injection, final List<Bson> aggregateOperations) {
+        boolean valueExists = false;
+        for (final Bson op : aggregateOperations) {
+            final BsonDocument doc = op.toBsonDocument();
+            valueExists = isValueExists(injection, doc);
+            if (valueExists) {
+                break;
+            }
+        }
+        Assertions.assertTrue(valueExists);
+    }
+
+    private static boolean isValueExists(final @NonNull String injection, final BsonDocument doc) {
+        boolean valueExists = false;
+        for (final Map.Entry<String, BsonValue> entry : doc.entrySet()) {
+            final BsonValue bsonValue = entry.getValue();
+            if (bsonValue.isDocument()) {
+                valueExists = isValueExists(injection, bsonValue.asDocument());
+                if (valueExists) {
+                    break;
+                }
+            } else if (bsonValue.isArray()) {
+                valueExists = isValueExists(injection, bsonValue.asArray());
+                if (valueExists) {
+                    break;
+                }
+            } else if (bsonValue.isString()) {
+                final String actualValue = bsonValue.asString().getValue();
+                if (injection.equals(actualValue)) {
+                    valueExists = true;
+                    break;
+                }
+            }
+        }
+        return valueExists;
+    }
+
+    private static boolean isValueExists(final @NonNull String injection, final BsonArray array) {
+        boolean valueExists = false;
+        for (final BsonValue arrayValue : array) {
+            if (arrayValue.isDocument()) {
+                valueExists = isValueExists(injection, arrayValue.asDocument());
+                if (valueExists) {
+                    break;
+                }
+            } else if (arrayValue.isArray()) {
+                valueExists = isValueExists(injection, arrayValue.asArray());
+                if (valueExists) {
+                    break;
+                }
+            } else if (arrayValue.isString()) {
+                final String actualValue = array.asString().getValue();
+                if (injection.equals(actualValue)) {
+                    valueExists = true;
+                    break;
+                }
+            }
+        }
+        return valueExists;
+    }
+
+    private static void assertKeyNotExists(final @NonNull String expectedKey, final BsonDocument doc) {
+        for (final Map.Entry<String, BsonValue> entry : doc.entrySet()) {
+            final String actualKey = entry.getKey();
+            Assertions.assertNotEquals(expectedKey, actualKey);
+            if (entry.getValue().isDocument()) {
+                assertKeyNotExists(expectedKey, entry.getValue().asDocument());
+            } else if (entry.getValue().isArray()) {
+                assertKeyNotExists(expectedKey, entry.getValue().asArray());
+            }
+        }
+    }
+
+    private static void assertKeyNotExists(final @NonNull String expectedKey, final BsonArray array) {
+        for (final BsonValue value : array) {
+            if (value.isDocument()) {
+                assertKeyNotExists(expectedKey, value.asDocument());
+            } else if (value.isArray()) {
+                assertKeyNotExists(expectedKey, value.asArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

[AD-997] Add tests to ensure SQL or mongo injection is not possible.

### Description

Add
- Tests for mongo injection
- Tests for SQL injection

### Related Issue

https://bitquill.atlassian.net/browse/AD-997

### Additional Reviewers
@affonsoBQ
@alinaliBQ
@andiem-bq
@alexey-temnikov
@birschick-bq
